### PR TITLE
feat: align media type with sd-jwt-vc draft 06

### DIFF
--- a/examples/sd-jwt-example/custom_header.ts
+++ b/examples/sd-jwt-example/custom_header.ts
@@ -31,7 +31,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
   // Issue a signed JWT credential with the specified claims and disclosures
   // Return a Encoded SD JWT. Issuer send the credential to the holder
   const credential = await sdjwt.issue(claims, disclosureFrame, {
-    header: { typ: 'vc+sd-jwt', custom: 'data' }, // You can add custom header data to the SD JWT
+    header: { typ: 'dc+sd-jwt', custom: 'data' }, // You can add custom header data to the SD JWT
   });
   console.log('encodedSdjwt:', credential);
 

--- a/examples/sd-jwt-vc-example/custom_header.ts
+++ b/examples/sd-jwt-vc-example/custom_header.ts
@@ -39,7 +39,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
     },
     disclosureFrame,
     {
-      header: { typ: 'vc+sd-jwt', custom: 'data' }, // You can add custom header data to the SD JWT
+      header: { typ: 'dc+sd-jwt', custom: 'data' }, // You can add custom header data to the SD JWT
     },
   );
   console.log('encodedSdjwt:', credential);

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -22,7 +22,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
   /**
    * The type of the SD-JWT-VC set in the header.typ field.
    */
-  protected type = 'vc+sd-jwt';
+  protected type = 'dc+sd-jwt';
 
   protected userConfig: SDJWTVCConfig = {};
 

--- a/packages/sd-jwt-vc/test/app-e2e.spec.ts
+++ b/packages/sd-jwt-vc/test/app-e2e.spec.ts
@@ -235,7 +235,7 @@ async function JSONtest(filename: string) {
 
   expect(validated).toBeDefined();
   expect(validated).toStrictEqual({
-    header: { alg: 'EdDSA', typ: 'vc+sd-jwt' },
+    header: { alg: 'EdDSA', typ: 'dc+sd-jwt' },
     payload,
   });
 
@@ -259,7 +259,7 @@ async function JSONtest(filename: string) {
 
   expect(verified).toBeDefined();
   expect(verified).toStrictEqual({
-    header: { alg: 'EdDSA', typ: 'vc+sd-jwt' },
+    header: { alg: 'EdDSA', typ: 'dc+sd-jwt' },
     kb: undefined,
     payload,
   });


### PR DESCRIPTION
Draft 06 changes the media type from `vc+sd-jwt` to `dc+sd-jwt`.
https://author-tools.ietf.org/iddiff?url1=draft-ietf-oauth-sd-jwt-vc-05&url2=draft-ietf-oauth-sd-jwt-vc-06&difftype=--html
https://github.com/oauth-wg/oauth-sd-jwt-vc/pull/268