### PR TITLE
feat: align type metadata fetching with sd-jwt-vc draft 08

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Hopae, a founding member of OpenWallet Foundation, is building wallet module in 
 Currently compliant with:
 
 - **[draft-ietf-oauth-selective-disclosure-jwt-13](https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/)**
-- **[draft-ietf-oauth-sd-jwt-vc-05](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/)**
+- **[draft-ietf-oauth-sd-jwt-vc-08](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/)**
 - **[draft-ietf-oauth-status-list-05](https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/)**
 
 ## **Background**

--- a/docs/index.html
+++ b/docs/index.html
@@ -101,7 +101,7 @@
       <div class="mb-4">
         <ul class="list-disc pl-5 space-y-2">
           <li>SD-JWT: <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt" target="_blank"><b>draft-ietf-oauth-selective-disclosure-jwt-13</b></a></li>
-          <li>SD-JWT VC: <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/" target="_blank"><b>draft-ietf-oauth-sd-jwt-vc-05</b></a></li>
+          <li>SD-JWT VC: <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/" target="_blank"><b>draft-ietf-oauth-sd-jwt-vc-08</b></a></li>
           <li>Token Status List: <a href="https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/" target="_blank"><b>draft-ietf-oauth-status-list-05</b></a></li>
         </ul>
       </div>

--- a/packages/sd-jwt-vc/README.md
+++ b/packages/sd-jwt-vc/README.md
@@ -103,7 +103,7 @@ const sdjwt = new SDJwtVcInstance({
 });
 ```
 
-The library will load load the type metadata format based on the `vct` value according to the [SD-JWT-VC specification](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-04.html#name-type-metadata) and validate this schema.
+The library will load load the type metadata format based on the `vct` value according to the [SD-JWT-VC specification](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-08.html#name-sd-jwt-vc-type-metadata) and validate this schema.
 
 Since at this point the display is not yet implemented, the library will only validate the schema and return the type metadata format. In the future the values of the type metadata can be fetched via a function call.
 

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -40,7 +40,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
   protected validateReservedFields(
     disclosureFrame: DisclosureFrame<SdJwtVcPayload>,
   ): void {
-    //validate disclosureFrame according to https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-03.html#section-3.2.2.2
+    //validate disclosureFrame according to https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-08.html#section-3.2.2.2
     if (
       disclosureFrame?._sd &&
       Array.isArray(disclosureFrame._sd) &&
@@ -131,23 +131,6 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
   }
 
   /**
-   * Default function to fetch the VCT from the uri. We assume that the vct is a URL that is used to fetch the VCT.
-   * @param uri
-   * @returns
-   */
-  private async vctFetcher(
-    uri: string,
-    integrity?: string,
-  ): Promise<TypeMetadataFormat> {
-    // modify the uri based on https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-04.html#section-6.3.1
-    const elements = uri.split('/');
-    //insert a new element on the thrid position, but not replace it
-    elements.splice(3, 0, '.well-known/vct');
-    const url = elements.join('/');
-    return this.fetch<TypeMetadataFormat>(url, integrity);
-  }
-
-  /**
    * Validates the integrity of the response if the integrity is passed. If the integrity does not match, an error is thrown.
    * @param integrity
    * @param response
@@ -227,14 +210,15 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
     result: VerificationResult,
   ): Promise<TypeMetadataFormat | undefined> {
     const fetcher: VcTFetcher =
-      this.userConfig.vctFetcher ?? this.vctFetcher.bind(this);
+      this.userConfig.vctFetcher ??
+      ((uri, integrity) => this.fetch(uri, integrity));
     const typeMetadataFormat = await fetcher(
       result.payload.vct,
       result.payload['vct#Integrity'],
     );
 
     if (typeMetadataFormat.extends) {
-      // implement based on https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-04.html#name-extending-type-metadata
+      // implement based on https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-08.html#name-extending-type-metadata
       //TODO: needs to be implemented. Unclear at this point which values will overwrite the values from the extended type metadata format
     }
 

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-type-metadata-format.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-type-metadata-format.ts
@@ -1,5 +1,5 @@
 /**
- * https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-04.html#name-type-metadata-format
+ * https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-08.html#name-type-metadata-format
  */
 export type TypeMetadataFormat = {
   vct: string; // REQUIRED. A URI that uniquely identifies the type. This URI MUST be dereferenceable to a JSON document that describes the type.

--- a/packages/sd-jwt-vc/src/test/vct.spec.ts
+++ b/packages/sd-jwt-vc/src/test/vct.spec.ts
@@ -41,7 +41,7 @@ const restHandlers = [
     };
     return HttpResponse.json(res);
   }),
-  http.get('http://exmaple.com/.well-known/vct/example', () => {
+  http.get('http://exmaple.com/example', () => {
     const res: TypeMetadataFormat = {
       vct: 'http://example.com/example',
       name: 'ExampleCredentialType',


### PR DESCRIPTION
Draft 07 removes the `.well-known/vct/` addition to the `vct` URI when fetching the Type Metadata. Draft 08 is the latest.