### PR TITLE
chore: fix lerna lint error

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -4,7 +4,7 @@
     "enabled": false
   },
   "files": {
-    "ignore": ["**/dist/**", "**/coverage/**", "package.json"]
+    "ignore": ["**/dist/**", "**/coverage/**", "package.json", "lerna.json"]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
ignore lerna file for linting checks since it gets formatted and breaks the current rule.

Signed-off-by: Mirko Mollik <mirkomollik@gmail.com>