### PR TITLE
chore: lowercase sha algorithm to be compliant

### DIFF
--- a/docs/0.x/sdjwt-instance.md
+++ b/docs/0.x/sdjwt-instance.md
@@ -10,7 +10,7 @@ const sdjwt = new SDJwtInstance({
   verifier,
   signAlg: 'EdDSA',
   hasher: digest,
-  hashAlg: 'SHA-256',
+  hashAlg: 'sha-256',
   saltGenerator: generateSalt,
 });
 ```
@@ -33,7 +33,7 @@ type SDJWTConfig = {
   omitTyp?: boolean;
   // hash function: (data: string) => Promise<string> or string;
   hasher?: Hasher;
-  // hash algorithm string (e.g. 'SHA-256')
+  // hash algorithm string (e.g. 'sha-256')
   hashAlg?: string;
   // salt generate function: (length: number) => Promise<string> or string;
   saltGenerator?: SaltGenerator;

--- a/examples/sd-jwt-example/all.ts
+++ b/examples/sd-jwt-example/all.ts
@@ -11,7 +11,7 @@ import { createSignerVerifier, digest, generateSalt, ES256 } from './utils';
     verifier,
     signAlg: ES256.alg,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
 

--- a/examples/sd-jwt-example/basic.ts
+++ b/examples/sd-jwt-example/basic.ts
@@ -11,7 +11,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
     verifier,
     signAlg: ES256.alg,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
 

--- a/examples/sd-jwt-example/custom.ts
+++ b/examples/sd-jwt-example/custom.ts
@@ -11,7 +11,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
     verifier,
     signAlg: ES256.alg,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
 

--- a/examples/sd-jwt-example/custom_header.ts
+++ b/examples/sd-jwt-example/custom_header.ts
@@ -11,7 +11,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
     verifier,
     signAlg: ES256.alg,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
 

--- a/examples/sd-jwt-example/decoy.ts
+++ b/examples/sd-jwt-example/decoy.ts
@@ -11,7 +11,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
     verifier,
     signAlg: ES256.alg,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
   // Issuer Define the claims object with the user's information

--- a/examples/sd-jwt-vc-example/all.ts
+++ b/examples/sd-jwt-vc-example/all.ts
@@ -11,7 +11,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
     verifier,
     signAlg: ES256.alg,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
 

--- a/examples/sd-jwt-vc-example/basic.ts
+++ b/examples/sd-jwt-vc-example/basic.ts
@@ -11,7 +11,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
     verifier,
     signAlg: ES256.alg,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
 

--- a/examples/sd-jwt-vc-example/custom.ts
+++ b/examples/sd-jwt-vc-example/custom.ts
@@ -11,7 +11,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
     verifier,
     signAlg: ES256.alg,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
 

--- a/examples/sd-jwt-vc-example/custom_header.ts
+++ b/examples/sd-jwt-vc-example/custom_header.ts
@@ -11,7 +11,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
     verifier,
     signAlg: ES256.alg,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
 

--- a/examples/sd-jwt-vc-example/decoy.ts
+++ b/examples/sd-jwt-vc-example/decoy.ts
@@ -11,7 +11,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
     verifier,
     signAlg: ES256.alg,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
   // Issuer Define the claims object with the user's information

--- a/package.json
+++ b/package.json
@@ -45,5 +45,6 @@
     "typescript": "^5.3.2",
     "vite": "^5.1.1",
     "vitest": "^1.2.2"
-  }
+  },
+  "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a"
 }

--- a/packages/browser-crypto/src/crypto.ts
+++ b/packages/browser-crypto/src/crypto.ts
@@ -15,7 +15,7 @@ export const generateSalt = (length: number): string => {
 
 export async function digest(
   data: string | ArrayBuffer,
-  algorithm = 'SHA-256',
+  algorithm = 'sha-256',
 ): Promise<Uint8Array> {
   const ec = new TextEncoder();
   const digest = await window.crypto.subtle.digest(
@@ -25,7 +25,7 @@ export async function digest(
   return new Uint8Array(digest);
 }
 
-export const getHasher = (algorithm = 'SHA-256') => {
+export const getHasher = (algorithm = 'sha-256') => {
   return (data: string) => digest(data, algorithm);
 };
 
@@ -72,7 +72,7 @@ export const ES256 = {
       const signature = await window.crypto.subtle.sign(
         {
           name: 'ECDSA',
-          hash: { name: 'SHA-256' }, // Required for ES256
+          hash: { name: 'sha-256' }, // Required for ES256
         },
         privateKey,
         encoder.encode(data),
@@ -107,7 +107,7 @@ export const ES256 = {
       const isValid = await window.crypto.subtle.verify(
         {
           name: 'ECDSA',
-          hash: { name: 'SHA-256' }, // Required for ES256
+          hash: { name: 'sha-256' }, // Required for ES256
         },
         publicKey,
         signature,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ import {
   type SDJWTConfig,
   type JwtPayload,
   type Signer,
+  type HashAlgorithm,
 } from '@sd-jwt/types';
 import { getSDAlgAndPayload } from '@sd-jwt/decode';
 import { FlattenJSON } from './flattenJSON';
@@ -31,6 +32,26 @@ export * from './generalJSON';
 
 export type SdJwtPayload = Record<string, unknown>;
 
+const IANA_HASH_ALGORITHMS: HashAlgorithm[] = [
+  'sha-256',
+  'sha-256-128',
+  'sha-256-120',
+  'sha-256-96',
+  'sha-256-64',
+  'sha-256-32',
+  'sha-384',
+  'sha-512',
+  'sha3-224',
+  'sha3-256',
+  'sha3-384',
+  'sha3-512',
+  'blake2s-256',
+  'blake2b-256',
+  'blake2b-512',
+  'k12-256',
+  'k12-512',
+];
+
 export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
   //header type
   protected type?: string;
@@ -41,6 +62,14 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
 
   constructor(userConfig?: SDJWTConfig) {
     if (userConfig) {
+      if (
+        userConfig.hashAlg &&
+        !IANA_HASH_ALGORITHMS.includes(userConfig.hashAlg)
+      ) {
+        throw new SDJWTException(
+          `Invalid hash algorithm: ${userConfig.hashAlg}`,
+        );
+      }
       this.userConfig = userConfig;
     }
   }
@@ -340,6 +369,14 @@ export class SDJwtGeneralJSONInstance<ExtendedPayload extends SdJwtPayload> {
 
   constructor(userConfig?: SDJWTConfig) {
     if (userConfig) {
+      if (
+        userConfig.hashAlg &&
+        !IANA_HASH_ALGORITHMS.includes(userConfig.hashAlg)
+      ) {
+        throw new SDJWTException(
+          `Invalid hash algorithm: ${userConfig.hashAlg}`,
+        );
+      }
       this.userConfig = userConfig;
     }
   }

--- a/packages/core/test/app-e2e.spec.ts
+++ b/packages/core/test/app-e2e.spec.ts
@@ -36,7 +36,7 @@ describe('App', () => {
       signAlg: 'EdDSA',
       verifier,
       hasher: digest,
-      hashAlg: 'SHA-256',
+      hashAlg: 'sha-256',
       saltGenerator: generateSalt,
     });
 
@@ -208,7 +208,7 @@ async function JSONtest(filename: string) {
     signAlg: 'EdDSA',
     verifier,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
 

--- a/packages/hash/src/test/sha256.spec.ts
+++ b/packages/hash/src/test/sha256.spec.ts
@@ -106,7 +106,7 @@ describe('SHA-256 tests', () => {
 
   test('Hasher', async () => {
     const s1 = bytesToHex(await digest('test'));
-    const s2 = bytesToHex(hasher('test', 'SHA-256'));
+    const s2 = bytesToHex(hasher('test', 'sha-256'));
     const s3 = bytesToHex(hasher('test', 'SHA256'));
     const s4 = bytesToHex(hasher('test', 'sha256'));
     const s5 = bytesToHex(hasher('test', 'sha-256'));

--- a/packages/node-crypto/src/crypto.ts
+++ b/packages/node-crypto/src/crypto.ts
@@ -11,7 +11,7 @@ export const generateSalt = (length: number): string => {
 
 export const digest = (
   data: string | ArrayBuffer,
-  algorithm = 'SHA-256',
+  algorithm = 'sha-256',
 ): Uint8Array => {
   const nodeAlg = toNodeCryptoAlg(algorithm);
   const hash = createHash(nodeAlg);
@@ -64,7 +64,7 @@ export const ES256 = {
       const signature = await subtle.sign(
         {
           name: 'ECDSA',
-          hash: { name: 'SHA-256' }, // Required for ES256
+          hash: { name: 'sha-256' }, // Required for ES256
         },
         privateKey,
         encoder.encode(data),
@@ -98,7 +98,7 @@ export const ES256 = {
       const isValid = await subtle.verify(
         {
           name: 'ECDSA',
-          hash: { name: 'SHA-256' }, // Required for ES256
+          hash: { name: 'sha-256' }, // Required for ES256
         },
         publicKey,
         signature,

--- a/packages/present/src/test/present.spec.ts
+++ b/packages/present/src/test/present.spec.ts
@@ -160,7 +160,7 @@ describe('Present tests', () => {
         'RrOc4ZfBVyD6iNlMbtmdokZOti322mOXfvIOBKvpuc4',
         'aXqInKwHoE1l8OM1VNUQDqTPeNUG1cMJVwVbxZJpP14',
       ],
-      _sd_alg: 'SHA-256',
+      _sd_alg: 'sha-256',
     };
 
     const presentationFrame = {
@@ -225,7 +225,7 @@ describe('Present tests', () => {
         'RrOc4ZfBVyD6iNlMbtmdokZOti322mOXfvIOBKvpuc4',
         'aXqInKwHoE1l8OM1VNUQDqTPeNUG1cMJVwVbxZJpP14',
       ],
-      _sd_alg: 'SHA-256',
+      _sd_alg: 'sha-256',
     };
 
     const presentationFrame = {};
@@ -265,7 +265,7 @@ describe('Present tests', () => {
         'RrOc4ZfBVyD6iNlMbtmdokZOti322mOXfvIOBKvpuc4',
         'aXqInKwHoE1l8OM1VNUQDqTPeNUG1cMJVwVbxZJpP14',
       ],
-      _sd_alg: 'SHA-256',
+      _sd_alg: 'sha-256',
     };
 
     const presentationFrame = {

--- a/packages/sd-jwt-vc/README.md
+++ b/packages/sd-jwt-vc/README.md
@@ -97,7 +97,7 @@ const sdjwt = new SDJwtVcInstance({
   signAlg: 'EdDSA',
   verifier,
   hasher: digest,
-  hashAlg: 'SHA-256',
+  hashAlg: 'sha-256',
   saltGenerator: generateSalt,
   loadTypeMetadataFormat: true,
 });

--- a/packages/sd-jwt-vc/src/test/index.spec.ts
+++ b/packages/sd-jwt-vc/src/test/index.spec.ts
@@ -67,7 +67,7 @@ describe('App', () => {
       signAlg: 'EdDSA',
       verifier,
       hasher: digest,
-      hashAlg: 'SHA-256',
+      hashAlg: 'sha-256',
       saltGenerator: generateSalt,
     });
 
@@ -94,7 +94,7 @@ describe('Revocation', () => {
     signAlg: 'EdDSA',
     verifier,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
     statusListFetcher(uri: string) {
       // we emulate fetching the status list from the uri. Validation of the JWT is not done here in the test but should be done in the implementation.

--- a/packages/sd-jwt-vc/src/test/vct.spec.ts
+++ b/packages/sd-jwt-vc/src/test/vct.spec.ts
@@ -97,7 +97,7 @@ describe('App', () => {
       signAlg: 'EdDSA',
       verifier,
       hasher: digest,
-      hashAlg: 'SHA-256',
+      hashAlg: 'sha-256',
       saltGenerator: generateSalt,
       loadTypeMetadataFormat: true,
     });

--- a/packages/sd-jwt-vc/test/app-e2e.spec.ts
+++ b/packages/sd-jwt-vc/test/app-e2e.spec.ts
@@ -40,7 +40,7 @@ describe('App', () => {
       signAlg: 'EdDSA',
       verifier,
       hasher: digest,
-      hashAlg: 'SHA-256',
+      hashAlg: 'sha-256',
       saltGenerator: generateSalt,
     });
 
@@ -222,7 +222,7 @@ async function JSONtest(filename: string) {
     signAlg: 'EdDSA',
     verifier,
     hasher: digest,
-    hashAlg: 'SHA-256',
+    hashAlg: 'sha-256',
     saltGenerator: generateSalt,
   });
 

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -167,15 +167,15 @@ type Frame<Payload> = Payload extends Array<infer U>
     ? Record<number, Frame<U>> & SD<Payload> & DECOY
     : SD<Payload> & DECOY
   : Payload extends Record<string, unknown>
-  ? NonNever<
-      {
-        [K in keyof Payload]?: Payload[K] extends object
-          ? Frame<Payload[K]>
-          : never;
-      } & SD<Payload> &
-        DECOY
-    >
-  : SD<Payload> & DECOY;
+    ? NonNever<
+        {
+          [K in keyof Payload]?: Payload[K] extends object
+            ? Frame<Payload[K]>
+            : never;
+        } & SD<Payload> &
+          DECOY
+      >
+    : SD<Payload> & DECOY;
 
 /**
  * This is a disclosureFrame type that is used to represent the structure of what is being disclosed.

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -9,10 +9,30 @@ export type Base64urlString = string;
 
 export type DisclosureData<T> = [string, string, T] | [string, T];
 
+// based on https://www.iana.org/assignments/named-information/named-information.xhtml
+export type HashAlgorithm =
+  | 'sha-256'
+  | 'sha-256-128'
+  | 'sha-256-120'
+  | 'sha-256-96'
+  | 'sha-256-64'
+  | 'sha-256-32'
+  | 'sha-384'
+  | 'sha-512'
+  | 'sha3-224'
+  | 'sha3-256'
+  | 'sha3-384'
+  | 'sha3-512'
+  | 'blake2s-256'
+  | 'blake2b-256'
+  | 'blake2b-512'
+  | 'k12-256'
+  | 'k12-512';
+
 export type SDJWTConfig = {
   omitTyp?: boolean;
   hasher?: Hasher;
-  hashAlg?: string;
+  hashAlg?: HashAlgorithm;
   saltGenerator?: SaltGenerator;
   signer?: Signer;
   signAlg?: string;
@@ -147,15 +167,15 @@ type Frame<Payload> = Payload extends Array<infer U>
     ? Record<number, Frame<U>> & SD<Payload> & DECOY
     : SD<Payload> & DECOY
   : Payload extends Record<string, unknown>
-    ? NonNever<
-        {
-          [K in keyof Payload]?: Payload[K] extends object
-            ? Frame<Payload[K]>
-            : never;
-        } & SD<Payload> &
-          DECOY
-      >
-    : SD<Payload> & DECOY;
+  ? NonNever<
+      {
+        [K in keyof Payload]?: Payload[K] extends object
+          ? Frame<Payload[K]>
+          : never;
+      } & SD<Payload> &
+        DECOY
+    >
+  : SD<Payload> & DECOY;
 
 /**
  * This is a disclosureFrame type that is used to represent the structure of what is being disclosed.


### PR DESCRIPTION
Closes #264

Renaming `SHA-256` to `sha-256` to be compliant with iana naming as described in the issue.

I also added the type based on the iana values so autocomplete should warn the user when they use a wrong value and we are checking it during issuance (we do not this during decoding in case the sd jwt was created by another tool, ignoring these rules)