### PR TITLE
type: define IANA hash algorithm list once

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ import {
   type SDJWTConfig,
   type JwtPayload,
   type Signer,
+  IANA_HASH_ALGORITHMS,
   type HashAlgorithm,
 } from '@sd-jwt/types';
 import { getSDAlgAndPayload } from '@sd-jwt/decode';
@@ -31,26 +32,6 @@ export * from './flattenJSON';
 export * from './generalJSON';
 
 export type SdJwtPayload = Record<string, unknown>;
-
-const IANA_HASH_ALGORITHMS: HashAlgorithm[] = [
-  'sha-256',
-  'sha-256-128',
-  'sha-256-120',
-  'sha-256-96',
-  'sha-256-64',
-  'sha-256-32',
-  'sha-384',
-  'sha-512',
-  'sha3-224',
-  'sha3-256',
-  'sha3-384',
-  'sha3-512',
-  'blake2s-256',
-  'blake2b-256',
-  'blake2b-512',
-  'k12-256',
-  'k12-512',
-];
 
 export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
   //header type

--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -10,24 +10,28 @@ export type Base64urlString = string;
 export type DisclosureData<T> = [string, string, T] | [string, T];
 
 // based on https://www.iana.org/assignments/named-information/named-information.xhtml
-export type HashAlgorithm =
-  | 'sha-256'
-  | 'sha-256-128'
-  | 'sha-256-120'
-  | 'sha-256-96'
-  | 'sha-256-64'
-  | 'sha-256-32'
-  | 'sha-384'
-  | 'sha-512'
-  | 'sha3-224'
-  | 'sha3-256'
-  | 'sha3-384'
-  | 'sha3-512'
-  | 'blake2s-256'
-  | 'blake2b-256'
-  | 'blake2b-512'
-  | 'k12-256'
-  | 'k12-512';
+export const IANA_HASH_ALGORITHMS = [
+  'sha-256',
+  'sha-256-128',
+  'sha-256-120',
+  'sha-256-96',
+  'sha-256-64',
+  'sha-256-32',
+  'sha-384',
+  'sha-512',
+  'sha3-224',
+  'sha3-256',
+  'sha3-384',
+  'sha3-512',
+  'blake2s-256',
+  'blake2b-256',
+  'blake2b-512',
+  'k12-256',
+  'k12-512',
+] as const;
+
+export type HashAlgorithm = (typeof IANA_HASH_ALGORITHMS)[number];
+
 
 export type SDJWTConfig = {
   omitTyp?: boolean;


### PR DESCRIPTION
Noticed that PR #266 can be improved a bit. It is possible to utilise Typescript's [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) and derive the `HashAlgorithm` type from the `IANA_HASH_ALGORITHMS` array, making it unnecessary to duplicate the algorithm list for both the type and the run-time array. This requires moving the `IANA_HASH_ALGORITHMS` array to the `types` package and exporting it from there.