### PR TITLE
chore: fix typo

### DIFF
--- a/examples/sd-jwt-example/generalJSON.ts
+++ b/examples/sd-jwt-example/generalJSON.ts
@@ -37,7 +37,7 @@ import { createSignerVerifier, digest, generateSalt, ES256 } from './utils';
   console.log('encodedSdjwt:', encodedSdjwt);
 
   const generalJSON = GeneralJSON.fromEncode(encodedSdjwt);
-  console.log('flattenJSON(credential): ', generalJSON.toJson());
+  console.log('generalJSON(credential): ', generalJSON.toJson());
 
   const presentedSdJwt = await sdjwt.present<typeof claims>(
     encodedSdjwt,


### PR DESCRIPTION
Hello! I noticed a typo in the sd-jwt generalJSON example logs while using the feature. 
I corrected 'flattenJSON(credential):' to 'generalJSON(credential)'.

Thank you for creating such a valuable library! :)

