### PR TITLE
fix: Frame fails when a type with an optional or nullable field is used

### DIFF
--- a/packages/types/src/type.ts
+++ b/packages/types/src/type.ts
@@ -172,7 +172,7 @@ type Frame<Payload> = Payload extends Array<infer U>
   : Payload extends Record<string, unknown>
     ? NonNever<
         {
-          [K in keyof Payload]?: Payload[K] extends object
+          [K in keyof Payload]?: NonNullable<Payload[K]> extends object
             ? Frame<Payload[K]>
             : never;
         } & SD<Payload> &
@@ -235,7 +235,7 @@ type PFrame<Payload> = Payload extends Array<infer U>
     ? Record<number, PFrame<U> | boolean> | boolean
     : Record<number, boolean> | boolean
   : {
-      [K in keyof Payload]?: Payload[K] extends object
+      [K in keyof Payload]?: NonNullable<Payload[K]> extends object
         ? PFrame<Payload[K]> | boolean
         : boolean;
     };


### PR DESCRIPTION
Types such as the following currently fail when trying to make the nested fields selectively discloseable:

```ts
type PID = {
    given_name: string;
    address?: {
        country: string;
    }
};

const disclosureFrame: DisclosureFrame<PID> = {
    _sd: ['given_name'],
    address: {
        _sd: ['country']
    }
};

```

Signed-off-by: Stefan Charsley <charsleysa@gmail.com>