### PR TITLE
doc: Improve the Documentation link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -113,7 +113,7 @@
       </p>
       <div class="flex justify-center items-center gap-4 pb-6">
         <a
-          href="https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki"
+          href="https://github.com/openwallet-foundation/sd-jwt-js/tree/main/docs"
           class="bg-black text-white font-bold py-2 px-6 rounded hover:bg-gray-700 transition-colors duration-150 ease-in-out"
           target="_blank"
           >Documentation</a


### PR DESCRIPTION
Having the "Documentation" link point at the documentation of this library instead of [another deprecated library](https://www.npmjs.com/package/@hopae/sd-jwt).
