### PR TITLE
doc: Update documents to match with current code

### DIFF
--- a/docs/0.x/issue.md
+++ b/docs/0.x/issue.md
@@ -1,12 +1,12 @@
 ## Overview
 
 ```ts
-const encodedSdjwt = await sdjwt.issue(claims, disclosureFrame, options);
+const encodedSdjwt = await sdjwt.issue(payload, disclosureFrame, options);
 ```
 
 ## Parameters
 
-- claims: the payload of SD JWT [Object]
+- payload: the payload of SD JWT [Object]
 - disclosureFrame: to define which properties should be selectively diclosable (optional, if not provided, there is no disclosure)
 - options: (optional)
 

--- a/docs/0.x/present.md
+++ b/docs/0.x/present.md
@@ -1,11 +1,18 @@
 ```ts
-const presentedSDJwt = await sdjwt.present(encodedSdjwt, presentationFrame);
+const presentedSDJwt = await sdjwt.present(encodedSdjwt, presentationFrame, options);
 ```
 
 ## Parameters
 
 - encodedSdjwt: encoded SD JWT [string]
 - presentationFrame: Represent the properties that should be selectively disclosed [object]
+- options: (optional)
+
+```ts
+options?: {
+  kb?: KBOptions; // options for Key Binding
+},
+```
 
 ### PresentationFrame
 

--- a/docs/0.x/sdjwt-instance.md
+++ b/docs/0.x/sdjwt-instance.md
@@ -55,12 +55,12 @@ type SDJWTConfig = {
 
 ## Methods
 
-- issue(claims, privateKey[, disclosureFrame, options])
-- present(encodedSDJwt[, presentationKeys])
-- validate(encodedSDJwt, publicKey)
-- verify(encodedSDJwt, publicKey[, requiredClaimKeys, options])
-- config(config)
-- encode(sdjwt)
+- issue(payload[, disclosureFrame, options])
+- present(encodedSDJwt[, presentationFrame, options])
+- validate(encodedSDJwt)
+- verify(encodedSDJwt[, requiredClaimKeys, requireKeyBindings])
+- config(newConfig)
+- encode(sdJwt)
 - decode(encodedSDJwt)
 - keys(encodedSDJwt)
 - presentableKeys(encodedSDJwt)


### PR DESCRIPTION
Updating 0.x version Documentation to match with current code.

* Remove `publicKey` and `privateKey` arguments from the Methods
* Add `options` argument to `present`
* Adjust namese of arguments
