### PR TITLE
validate timestamp and set custom date

### DIFF
--- a/examples/sd-jwt-vc-example/all.ts
+++ b/examples/sd-jwt-vc-example/all.ts
@@ -56,7 +56,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
   const credential = await sdjwt.issue(
     {
       iss: 'Issuer',
-      iat: new Date().getTime(),
+      iat: Math.floor(Date.now() / 1000),
       vct: 'ExampleCredentials',
       ...claims,
     },

--- a/examples/sd-jwt-vc-example/basic.ts
+++ b/examples/sd-jwt-vc-example/basic.ts
@@ -33,7 +33,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
   const credential = await sdjwt.issue(
     {
       iss: 'Issuer',
-      iat: new Date().getTime(),
+      iat: Math.floor(Date.now() / 1000),
       vct: 'ExampleCredentials',
       ...claims,
     },

--- a/examples/sd-jwt-vc-example/custom.ts
+++ b/examples/sd-jwt-vc-example/custom.ts
@@ -33,7 +33,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
   const credential = await sdjwt.issue(
     {
       iss: 'Issuer',
-      iat: new Date().getTime(),
+      iat: Math.floor(Date.now() / 1000),
       vct: 'ExampleCredentials',
       ...claims,
     },

--- a/examples/sd-jwt-vc-example/custom_header.ts
+++ b/examples/sd-jwt-vc-example/custom_header.ts
@@ -33,7 +33,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
   const credential = await sdjwt.issue(
     {
       iss: 'Issuer',
-      iat: new Date().getTime(),
+      iat: Math.floor(Date.now() / 1000),
       vct: 'ExampleCredentials',
       ...claims,
     },

--- a/examples/sd-jwt-vc-example/decoy.ts
+++ b/examples/sd-jwt-vc-example/decoy.ts
@@ -29,7 +29,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
   const credential = await sdjwt.issue(
     {
       iss: 'Issuer',
-      iat: new Date().getTime(),
+      iat: Math.floor(Date.now() / 1000),
       vct: 'ExampleCredentials',
       ...claims,
     },

--- a/examples/sd-jwt-vc-example/kb.ts
+++ b/examples/sd-jwt-vc-example/kb.ts
@@ -36,7 +36,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
   const encodedSdjwt = await sdjwt.issue(
     {
       iss: 'Issuer',
-      iat: new Date().getTime(),
+      iat: Math.floor(Date.now() / 1000),
       vct: 'ExampleCredentials',
       ...claims,
     },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -276,11 +276,14 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
   /**
    * This function is for validating the SD JWT
    * Checking signature, if provided the iat and exp when provided and return its the claims
-   * @param encodedSDJwt 
-   * @param currentDate 
-   * @returns 
+   * @param encodedSDJwt
+   * @param currentDate
+   * @returns
    */
-  public async validate(encodedSDJwt: string, currentDate: number = Math.floor(Date.now() / 1000)) {
+  public async validate(
+    encodedSDJwt: string,
+    currentDate: number = Math.floor(Date.now() / 1000),
+  ) {
     if (!this.userConfig.hasher) {
       throw new SDJWTException('Hasher not found');
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,11 +86,11 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
     return jwt;
   }
 
-  private async VerifyJwt(jwt: Jwt) {
+  private async VerifyJwt(jwt: Jwt, currentDate: number) {
     if (!this.userConfig.verifier) {
       throw new SDJWTException('Verifier not found');
     }
-    return jwt.verify(this.userConfig.verifier);
+    return jwt.verify(this.userConfig.verifier, currentDate);
   }
 
   public async issue<Payload extends ExtendedPayload>(
@@ -273,9 +273,14 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
     return sdHashStr;
   }
 
-  // This function is for validating the SD JWT
-  // Just checking signature and return its the claims
-  public async validate(encodedSDJwt: string) {
+  /**
+   * This function is for validating the SD JWT
+   * Checking signature, if provided the iat and exp when provided and return its the claims
+   * @param encodedSDJwt 
+   * @param currentDate 
+   * @returns 
+   */
+  public async validate(encodedSDJwt: string, currentDate: number = Math.floor(Date.now() / 1000)) {
     if (!this.userConfig.hasher) {
       throw new SDJWTException('Hasher not found');
     }
@@ -286,7 +291,7 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
       throw new SDJWTException('Invalid SD JWT');
     }
 
-    const verifiedPayloads = await this.VerifyJwt(sdjwt.jwt);
+    const verifiedPayloads = await this.VerifyJwt(sdjwt.jwt, currentDate);
     const claims = await sdjwt.getClaims(hasher);
     return { payload: claims, header: verifiedPayloads.header };
   }

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -113,7 +113,26 @@ export class Jwt<
     return compact;
   }
 
-  public async verify(verifier: Verifier) {
+
+  /**
+   * Verify the JWT using the provided verifier function.
+   * It checks the signature and validates the iat, nbf, and exp claims if they are present.
+   * @param verifier 
+   * @param currentDate 
+   * @returns 
+   */
+  public async verify(verifier: Verifier, currentDate = Math.floor(Date.now() / 1000)) {
+    if(this.payload?.iat && this.payload.iat as number > currentDate) {
+      throw new SDJWTException('Verify Error: JWT is not yet valid');
+    }
+
+    if(this.payload?.nbf && this.payload.nbf as number > currentDate) {
+      throw new SDJWTException('Verify Error: JWT is not yet valid');
+    }
+    if (this.payload?.exp && this.payload.exp as number < currentDate) {
+      throw new SDJWTException('Verify Error: JWT is expired');
+    }
+
     if (!this.signature) {
       throw new SDJWTException('Verify Error: no signature in JWT');
     }

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -113,23 +113,25 @@ export class Jwt<
     return compact;
   }
 
-
   /**
    * Verify the JWT using the provided verifier function.
    * It checks the signature and validates the iat, nbf, and exp claims if they are present.
-   * @param verifier 
-   * @param currentDate 
-   * @returns 
+   * @param verifier
+   * @param currentDate
+   * @returns
    */
-  public async verify(verifier: Verifier, currentDate = Math.floor(Date.now() / 1000)) {
-    if(this.payload?.iat && this.payload.iat as number > currentDate) {
+  public async verify(
+    verifier: Verifier,
+    currentDate = Math.floor(Date.now() / 1000),
+  ) {
+    if (this.payload?.iat && (this.payload.iat as number) > currentDate) {
       throw new SDJWTException('Verify Error: JWT is not yet valid');
     }
 
-    if(this.payload?.nbf && this.payload.nbf as number > currentDate) {
+    if (this.payload?.nbf && (this.payload.nbf as number) > currentDate) {
       throw new SDJWTException('Verify Error: JWT is not yet valid');
     }
-    if (this.payload?.exp && this.payload.exp as number < currentDate) {
+    if (this.payload?.exp && (this.payload.exp as number) < currentDate) {
       throw new SDJWTException('Verify Error: JWT is expired');
     }
 

--- a/packages/core/src/test/index.spec.ts
+++ b/packages/core/src/test/index.spec.ts
@@ -49,7 +49,7 @@ describe('index', () => {
       {
         foo: 'bar',
         iss: 'Issuer',
-        iat: new Date().getTime(),
+        iat: Math.floor(Date.now() / 1000),
         vct: '',
       },
       {
@@ -89,7 +89,7 @@ describe('index', () => {
       {
         foo: 'bar',
         iss: 'Issuer',
-        iat: new Date().getTime(),
+        iat: Math.floor(Date.now() / 1000),
         vct: '',
       },
       {
@@ -124,7 +124,7 @@ describe('index', () => {
       {
         foo: 'bar',
         iss: 'Issuer',
-        iat: new Date().getTime(),
+        iat: Math.floor(Date.now() / 1000),
         vct: '',
       },
       {
@@ -165,7 +165,7 @@ describe('index', () => {
       {
         foo: 'bar',
         iss: 'Issuer',
-        iat: new Date().getTime(),
+        iat: Math.floor(Date.now() / 1000),
         vct: '',
       },
       {
@@ -239,7 +239,7 @@ describe('index', () => {
     const credential = await sdjwt.issue(
       {
         foo: 'bar',
-        iat: new Date().getTime(),
+        iat: Math.floor(new Date().getTime() / 1000),
         cnf: {
           jwk: await exportJWK(publicKey),
         },
@@ -274,7 +274,7 @@ describe('index', () => {
         {
           foo: 'bar',
           iss: 'Issuer',
-          iat: new Date().getTime(),
+          iat: Math.floor(Date.now() / 1000),
           vct: '',
         },
         {
@@ -297,7 +297,7 @@ describe('index', () => {
         {
           foo: 'bar',
           iss: 'Issuer',
-          iat: new Date().getTime(),
+          iat: Math.floor(Date.now() / 1000),
           vct: '',
         },
         {
@@ -321,7 +321,7 @@ describe('index', () => {
         {
           foo: 'bar',
           iss: 'Issuer',
-          iat: new Date().getTime(),
+          iat: Math.floor(Date.now() / 1000),
           vct: '',
         },
         {
@@ -351,7 +351,7 @@ describe('index', () => {
       {
         foo: 'bar',
         iss: 'Issuer',
-        iat: new Date().getTime(),
+        iat: Math.floor(Date.now() / 1000),
         vct: '',
       },
       {
@@ -395,7 +395,7 @@ describe('index', () => {
       {
         foo: 'bar',
         iss: 'Issuer',
-        iat: new Date().getTime(),
+        iat: Math.floor(Date.now() / 1000),
         vct: '',
       },
       {
@@ -437,7 +437,7 @@ describe('index', () => {
       {
         foo: 'bar',
         iss: 'Issuer',
-        iat: new Date().getTime(),
+        iat: Math.floor(Date.now() / 1000),
         vct: '',
       },
       {
@@ -480,7 +480,7 @@ describe('index', () => {
       {
         foo: 'bar',
         iss: 'Issuer',
-        iat: new Date().getTime(),
+        iat: Math.floor(Date.now() / 1000),
         vct: '',
       },
       {
@@ -518,7 +518,7 @@ describe('index', () => {
       {
         foo: 'bar',
         iss: 'Issuer',
-        iat: new Date().getTime(),
+        iat: Math.floor(Date.now() / 1000),
         vct: '',
       },
       {
@@ -547,7 +547,7 @@ describe('index', () => {
       {
         foo: 'bar',
         iss: 'Issuer',
-        iat: new Date().getTime(),
+        iat: Math.floor(Date.now() / 1000),
         vct: '',
       },
       {
@@ -573,7 +573,7 @@ describe('index', () => {
       {
         foo: 'bar',
         iss: 'Issuer',
-        iat: new Date().getTime(),
+        iat: Math.floor(Date.now() / 1000),
         vct: '',
       },
       {

--- a/packages/core/src/test/index.spec.ts
+++ b/packages/core/src/test/index.spec.ts
@@ -239,7 +239,7 @@ describe('index', () => {
     const credential = await sdjwt.issue(
       {
         foo: 'bar',
-        iat: Math.floor(new Date().getTime() / 1000),
+        iat: Math.floor(Date.now() / 1000),
         cnf: {
           jwk: await exportJWK(publicKey),
         },

--- a/packages/core/src/test/jwt.spec.ts
+++ b/packages/core/src/test/jwt.spec.ts
@@ -213,14 +213,16 @@ describe('JWT', () => {
 
     const jwt = new Jwt({
       header: { alg: 'EdDSA' },
-      payload: { iat: Math.floor(Date.now () / 1000 ) + 100 },
+      payload: { iat: Math.floor(Date.now() / 1000) + 100 },
     });
 
     try {
       await jwt.verify(testVerifier);
-    } catch (e: unknown) {      
+    } catch (e: unknown) {
       expect(e).toBeInstanceOf(SDJWTException);
-      expect((e as SDJWTException).message).toBe('Verify Error: JWT is not yet valid');
+      expect((e as SDJWTException).message).toBe(
+        'Verify Error: JWT is not yet valid',
+      );
     }
   });
 
@@ -237,14 +239,16 @@ describe('JWT', () => {
 
     const jwt = new Jwt({
       header: { alg: 'EdDSA' },
-      payload: { nbf: Math.floor(Date.now () / 1000 ) + 100 },
+      payload: { nbf: Math.floor(Date.now() / 1000) + 100 },
     });
 
     try {
       await jwt.verify(testVerifier);
-    } catch (e: unknown) {      
+    } catch (e: unknown) {
       expect(e).toBeInstanceOf(SDJWTException);
-      expect((e as SDJWTException).message).toBe('Verify Error: JWT is not yet valid');
+      expect((e as SDJWTException).message).toBe(
+        'Verify Error: JWT is not yet valid',
+      );
     }
   });
 
@@ -261,14 +265,16 @@ describe('JWT', () => {
 
     const jwt = new Jwt({
       header: { alg: 'EdDSA' },
-      payload: { exp: Math.floor(Date.now () / 1000 ) },
+      payload: { exp: Math.floor(Date.now() / 1000) },
     });
 
     try {
-      await jwt.verify(testVerifier, Math.floor(Date.now () / 1000 ) + 100);
-    } catch (e: unknown) {      
+      await jwt.verify(testVerifier, Math.floor(Date.now() / 1000) + 100);
+    } catch (e: unknown) {
       expect(e).toBeInstanceOf(SDJWTException);
-      expect((e as SDJWTException).message).toBe('Verify Error: JWT is expired');
+      expect((e as SDJWTException).message).toBe(
+        'Verify Error: JWT is expired',
+      );
     }
   });
 });

--- a/packages/core/src/test/jwt.spec.ts
+++ b/packages/core/src/test/jwt.spec.ts
@@ -199,4 +199,76 @@ describe('JWT', () => {
       expect(e).toBeInstanceOf(SDJWTException);
     }
   });
+
+  test('verify with issuance date in the future', async () => {
+    const { privateKey, publicKey } = Crypto.generateKeyPairSync('ed25519');
+    const testVerifier: Verifier = async (data: string, sig: string) => {
+      return Crypto.verify(
+        null,
+        Buffer.from(data),
+        publicKey,
+        Buffer.from(sig, 'base64url'),
+      );
+    };
+
+    const jwt = new Jwt({
+      header: { alg: 'EdDSA' },
+      payload: { iat: Math.floor(Date.now () / 1000 ) + 100 },
+    });
+
+    try {
+      await jwt.verify(testVerifier);
+    } catch (e: unknown) {      
+      expect(e).toBeInstanceOf(SDJWTException);
+      expect((e as SDJWTException).message).toBe('Verify Error: JWT is not yet valid');
+    }
+  });
+
+  test('verify with not before in the future', async () => {
+    const { privateKey, publicKey } = Crypto.generateKeyPairSync('ed25519');
+    const testVerifier: Verifier = async (data: string, sig: string) => {
+      return Crypto.verify(
+        null,
+        Buffer.from(data),
+        publicKey,
+        Buffer.from(sig, 'base64url'),
+      );
+    };
+
+    const jwt = new Jwt({
+      header: { alg: 'EdDSA' },
+      payload: { nbf: Math.floor(Date.now () / 1000 ) + 100 },
+    });
+
+    try {
+      await jwt.verify(testVerifier);
+    } catch (e: unknown) {      
+      expect(e).toBeInstanceOf(SDJWTException);
+      expect((e as SDJWTException).message).toBe('Verify Error: JWT is not yet valid');
+    }
+  });
+
+  test('verify with expired', async () => {
+    const { privateKey, publicKey } = Crypto.generateKeyPairSync('ed25519');
+    const testVerifier: Verifier = async (data: string, sig: string) => {
+      return Crypto.verify(
+        null,
+        Buffer.from(data),
+        publicKey,
+        Buffer.from(sig, 'base64url'),
+      );
+    };
+
+    const jwt = new Jwt({
+      header: { alg: 'EdDSA' },
+      payload: { exp: Math.floor(Date.now () / 1000 ) },
+    });
+
+    try {
+      await jwt.verify(testVerifier, Math.floor(Date.now () / 1000 ) + 100);
+    } catch (e: unknown) {      
+      expect(e).toBeInstanceOf(SDJWTException);
+      expect((e as SDJWTException).message).toBe('Verify Error: JWT is expired');
+    }
+  });
 });

--- a/packages/core/test/app-e2e.spec.ts
+++ b/packages/core/test/app-e2e.spec.ts
@@ -224,7 +224,7 @@ async function JSONtest(filename: string) {
     payload: test.claims,
   });
 
-  const presentedSDJwt = await sdjwt.present<typeof claims>(
+  const presentedSDJwt = await sdjwt.present<typeof test.claims>(
     encodedSdjwt,
     test.presentationFrames,
   );

--- a/packages/jwt-status-list/README.md
+++ b/packages/jwt-status-list/README.md
@@ -6,10 +6,9 @@
 # SD-JWT Implementation in JavaScript (TypeScript)
 
 ## jwt-status-list
+
 An implementation of the [Token Status List](https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/) for a JWT representation, not for CBOR.
 This library helps to verify the status of a specific entry in a JWT, and to generate a status list and pack it into a signed JWT. It does not provide any functions to manage the status list itself.
-
-
 
 ## Installation
 
@@ -27,9 +26,11 @@ pnpm install @sd-jwt/jwt-status-list
 ```
 
 Ensure you have Node.js installed as a prerequisite.
+
 ## Usage
 
 Creation of a JWT Status List:
+
 ```typescript
 // pass the list as an array and the amount of bits per entry.
 const list = new StatusList([1, 0, 1, 1, 1], 1);
@@ -37,9 +38,9 @@ const iss = 'https://example.com';
 const payload: JWTPayload = {
     iss,
     sub: `${iss}/statuslist/1`,
-    iat: new Date().getTime() / 1000,
+    iat: Math.floor(Date.now() / 1000), // issued at time in seconds
     ttl: 3000, // time to live in seconds, optional
-    exp: new Date().getTime() / 1000 + 3600, // optional
+    exp: Math.floor(Date.now() / 1000) + 3600, // expiration time in seconds, optional
 };
 const header: JWTHeaderParameters = { alg: 'ES256' };
 
@@ -53,6 +54,7 @@ const jwt = await new SignJWT(values.payload)
 ```
 
 Interaction with a JWT status list on low level:
+
 ```typescript
 //validation of the JWT is not provided by this library!!!
 
@@ -72,9 +74,11 @@ const status = statusList.getStatus(reference.idx);
 ```
 
 ### Integration into sd-jwt-vc
+
 The status list can be integrated into the [sd-jwt-vc](../sd-jwt-vc/README.md) library to provide a way to verify the status of a credential. In the [test folder](../sd-jwt-vc/src/test/index.spec.ts) you will find an example how to add the status reference to a credential and also how to verify the status of a credential.
 
 ### Caching the status list
+
 Depending on the  `ttl` field if provided the status list can be cached for a certain amount of time. This library has no internal cache mechanism, so it is up to the user to implement it for example by providing a custom `fetchStatusList` function.
 
 ## Development

--- a/packages/jwt-status-list/src/test/status-list-jwt.spec.ts
+++ b/packages/jwt-status-list/src/test/status-list-jwt.spec.ts
@@ -37,7 +37,7 @@ describe('JWTStatusList', () => {
     const payload: JwtPayload = {
       iss,
       sub: `${iss}/statuslist/1`,
-      iat: new Date().getTime() / 1000,
+      iat: Math.floor(Date.now() / 1000)
     };
 
     const values = createHeaderAndPayload(statusList, payload, header);
@@ -61,7 +61,7 @@ describe('JWTStatusList', () => {
     const payload: JwtPayload = {
       iss,
       sub: `${iss}/statuslist/1`,
-      iat: new Date().getTime() / 1000,
+      iat: Math.floor(Date.now() / 1000)
     };
 
     const values = createHeaderAndPayload(statusList, payload, header);
@@ -82,7 +82,7 @@ describe('JWTStatusList', () => {
     const iss = 'https://example.com';
     let payload: JwtPayload = {
       sub: `${iss}/statuslist/1`,
-      iat: new Date().getTime() / 1000,
+      iat: Math.floor(Date.now() / 1000)
     };
     expect(() => {
       createHeaderAndPayload(statusList, payload as JwtPayload, header);
@@ -90,7 +90,7 @@ describe('JWTStatusList', () => {
 
     payload = {
       iss,
-      iat: new Date().getTime() / 1000,
+      iat: Math.floor(Date.now() / 1000)
     };
     expect(() => createHeaderAndPayload(statusList, payload, header)).toThrow(
       'sub field is required',
@@ -109,7 +109,7 @@ describe('JWTStatusList', () => {
     const payload: JWTwithStatusListPayload = {
       iss: 'https://example.com',
       sub: 'https://example.com/status/1',
-      iat: new Date().getTime() / 1000,
+      iat: Math.floor(Date.now() / 1000),
       status: {
         status_list: {
           idx: 0,

--- a/packages/jwt-status-list/src/test/status-list-jwt.spec.ts
+++ b/packages/jwt-status-list/src/test/status-list-jwt.spec.ts
@@ -37,7 +37,7 @@ describe('JWTStatusList', () => {
     const payload: JwtPayload = {
       iss,
       sub: `${iss}/statuslist/1`,
-      iat: Math.floor(Date.now() / 1000)
+      iat: Math.floor(Date.now() / 1000),
     };
 
     const values = createHeaderAndPayload(statusList, payload, header);
@@ -61,7 +61,7 @@ describe('JWTStatusList', () => {
     const payload: JwtPayload = {
       iss,
       sub: `${iss}/statuslist/1`,
-      iat: Math.floor(Date.now() / 1000)
+      iat: Math.floor(Date.now() / 1000),
     };
 
     const values = createHeaderAndPayload(statusList, payload, header);
@@ -82,7 +82,7 @@ describe('JWTStatusList', () => {
     const iss = 'https://example.com';
     let payload: JwtPayload = {
       sub: `${iss}/statuslist/1`,
-      iat: Math.floor(Date.now() / 1000)
+      iat: Math.floor(Date.now() / 1000),
     };
     expect(() => {
       createHeaderAndPayload(statusList, payload as JwtPayload, header);
@@ -90,7 +90,7 @@ describe('JWTStatusList', () => {
 
     payload = {
       iss,
-      iat: Math.floor(Date.now() / 1000)
+      iat: Math.floor(Date.now() / 1000),
     };
     expect(() => createHeaderAndPayload(statusList, payload, header)).toThrow(
       'sub field is required',

--- a/packages/sd-jwt-vc/README.md
+++ b/packages/sd-jwt-vc/README.md
@@ -41,7 +41,7 @@ import { DisclosureFrame } from '@sd-jwt/sd-jwt-vc';
 const iss = 'University';
 
 // issuance time
-const iat = new Date().getTime() / 1000;
+const iat = Math.floor(Date.now() / 1000); // current time in seconds
 
 //unique identifier of the schema
 const vct = 'University-Degree';

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -304,7 +304,10 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
    * @param result
    * @param currentDate current time in seconds
    */
-  private async verifyStatus(result: VerificationResult, currentDate: number): Promise<void> {
+  private async verifyStatus(
+    result: VerificationResult,
+    currentDate: number,
+  ): Promise<void> {
     if (result.payload.status) {
       //checks if a status field is present in the payload based on https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-02.html
       if (result.payload.status.status_list) {
@@ -325,10 +328,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
         await slJWT.verify(this.userConfig.verifier as Verifier, currentDate);
 
         //check if the status list is expired
-        if (
-          slJWT.payload?.exp &&
-          (slJWT.payload.exp as number) < currentDate
-        ) {
+        if (slJWT.payload?.exp && (slJWT.payload.exp as number) < currentDate) {
           throw new SDJWTException('Status list is expired');
         }
 

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -106,11 +106,13 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
 
   /**
    * Verifies the SD-JWT-VC. It will validate the signature, the keybindings when required, the status, and the VCT.
+   * @param currentDate current time in seconds
    */
   async verify(
     encodedSDJwt: string,
     requiredClaimKeys?: string[],
     requireKeyBindings?: boolean,
+    currentDate: number = Math.floor(Date.now() / 1000),
   ) {
     // Call the parent class's verify method
     const result: VerificationResult = await super
@@ -123,7 +125,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
         };
       });
 
-    await this.verifyStatus(result);
+    await this.verifyStatus(result, currentDate);
     if (this.userConfig.loadTypeMetadataFormat) {
       await this.verifyVct(result);
     }
@@ -300,8 +302,9 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
   /**
    * Verifies the status of the SD-JWT-VC.
    * @param result
+   * @param currentDate current time in seconds
    */
-  private async verifyStatus(result: VerificationResult): Promise<void> {
+  private async verifyStatus(result: VerificationResult, currentDate: number): Promise<void> {
     if (result.payload.status) {
       //checks if a status field is present in the payload based on https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-02.html
       if (result.payload.status.status_list) {
@@ -319,12 +322,12 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
           StatusListJWTPayload
         >(statusListJWT);
         // check if the status list has a valid signature. The presence of the verifier is checked in the parent class.
-        await slJWT.verify(this.userConfig.verifier as Verifier);
+        await slJWT.verify(this.userConfig.verifier as Verifier, currentDate);
 
         //check if the status list is expired
         if (
           slJWT.payload?.exp &&
-          (slJWT.payload.exp as number) < Date.now() / 1000
+          (slJWT.payload.exp as number) < currentDate
         ) {
           throw new SDJWTException('Status list is expired');
         }

--- a/packages/sd-jwt-vc/src/test/index.spec.ts
+++ b/packages/sd-jwt-vc/src/test/index.spec.ts
@@ -18,7 +18,7 @@ import { SignJWT } from 'jose';
 
 const iss = 'ExampleIssuer';
 const vct = 'ExampleCredentialType';
-const iat = new Date().getTime() / 1000;
+const iat = Math.floor(Date.now() / 1000);
 
 const { privateKey, publicKey } = Crypto.generateKeyPairSync('ed25519');
 
@@ -45,7 +45,7 @@ const generateStatusList = async (): Promise<string> => {
   const payload: JwtPayload = {
     iss: 'https://example.com',
     sub: 'https://example.com/status/1',
-    iat: new Date().getTime() / 1000,
+    iat: Math.floor(Date.now() / 1000),
   };
   const header: StatusListJWTHeaderParameters = {
     alg: 'EdDSA',

--- a/packages/sd-jwt-vc/src/test/vct.spec.ts
+++ b/packages/sd-jwt-vc/src/test/vct.spec.ts
@@ -70,7 +70,7 @@ const server = setupServer(...restHandlers);
 
 const iss = 'ExampleIssuer';
 const vct = 'http://example.com/example';
-const iat = new Date().getTime() / 1000;
+const iat = Math.floor(Date.now() / 1000); // current time in seconds
 
 const { privateKey, publicKey } = Crypto.generateKeyPairSync('ed25519');
 

--- a/packages/sd-jwt-vc/test/app-e2e.spec.ts
+++ b/packages/sd-jwt-vc/test/app-e2e.spec.ts
@@ -30,7 +30,7 @@ const createSignerVerifier = () => {
 
 const iss = 'ExampleIssuer';
 const vct = 'ExampleCredentials';
-const iat = new Date().getTime() / 1000;
+const iat = Math.floor(Date.now() / 1000); // current time in seconds
 
 describe('App', () => {
   test('Example', async () => {


### PR DESCRIPTION
closes #291 

Extending the validation of `iat`, `exp` and `nbf`. It is possible to pass a custom timestamp to the verify function.

We are not blocking credentials that will be issued with an `iat` value that is in the future, so the issuer has full control over it.