### PR TITLE
Use default fetcher to retrieve vct as URL

### DIFF
--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -292,6 +292,10 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
       return this.fetchVctFromHeader(result.payload.vct, result);
     }
 
+    if (result.payload.vct.startsWith('https')) {
+      return this.fetchVctFromUrl(result.payload.vct, result);
+    }
+
     const fetcher: VcTFetcher =
       this.userConfig.vctFetcher ??
       ((uri, integrity) => this.fetch(uri, integrity));
@@ -330,6 +334,13 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
     }
 
     return typeMetadataFormat;
+  }
+
+  private async fetchVctFromUrl(
+    vct: string,
+    result: VerificationResult,
+  ): Promise<TypeMetadataFormat> {
+    return this.fetch(vct, result.payload['vct#integrity'] as string);
   }
 
   /**

--- a/packages/sd-jwt-vc/src/test/vct.spec.ts
+++ b/packages/sd-jwt-vc/src/test/vct.spec.ts
@@ -155,6 +155,26 @@ describe('App', () => {
     await sdjwt.verify(encodedSdjwt);
   });
 
+  test('VCT from URL Validation', async () => {
+    const expectedPayload: SdJwtVcPayload = {
+      iat,
+      iss,
+      vct: 'http://example.com/example',
+      'vct#Integrity': vctIntegrity,
+      ...claims,
+    };
+    const header = {
+      vctm: [Buffer.from(JSON.stringify(exampleVctm)).toString('base64url')],
+    };
+    const encodedSdjwt = await sdjwt.issue(
+      expectedPayload,
+      disclosureFrame as unknown as DisclosureFrame<SdJwtVcPayload>,
+      { header },
+    );
+
+    await sdjwt.verify(encodedSdjwt);
+  });
+
   test('VCT Validation with timeout', async () => {
     const vct = 'http://example.com/timeout';
     const expectedPayload: SdJwtVcPayload = {


### PR DESCRIPTION
Here the point is to use the default fetcher to retrieve vct when it is expressed as an URL. The priority of vct retrieval would be then:
1. Use vctm in header if present
2. Use internal fetcher when vct is an URL
3. Use the custom (or default) fetcher for urns
