### PR TITLE
fix: claim type

### DIFF
--- a/packages/sd-jwt-vc/src/sd-jwt-vc-type-metadata-format.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-type-metadata-format.ts
@@ -110,7 +110,7 @@ export type Claim = {
    * REQUIRED. Array of one or more paths to the claim in the credential subject.
    * Each path is an array of strings (or null for array elements).
    */
-  path: ClaimPath[];
+  path: ClaimPath;
   /** OPTIONAL. Display metadata in multiple languages. */
   display?: ClaimDisplay[];
   /** OPTIONAL. Controls whether the claim must, may, or must not be selectively disclosed. */


### PR DESCRIPTION
setting the correct type for path. It was an array of array of strings, but one array is enough, see: https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-10.html#name-claim-metadata