### PR TITLE
Fix/248

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,7 +97,7 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
     payload: Payload,
     disclosureFrame?: DisclosureFrame<Payload>,
     options?: {
-      header?: object; // This is for customizing the header of the jwt
+      header?: object; // This is for customizing the header of the jwt      
     },
   ): Promise<SDJWTCompact> {
     if (!this.userConfig.hasher) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,7 +97,7 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
     payload: Payload,
     disclosureFrame?: DisclosureFrame<Payload>,
     options?: {
-      header?: object; // This is for customizing the header of the jwt      
+      header?: object; // This is for customizing the header of the jwt
     },
   ): Promise<SDJWTCompact> {
     if (!this.userConfig.hasher) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,10 +112,6 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
       throw new SDJWTException('sign alogrithm not specified');
     }
 
-    if (disclosureFrame) {
-      this.validateReservedFields<Payload>(disclosureFrame);
-    }
-
     const hasher = this.userConfig.hasher;
     const hashAlg = this.userConfig.hashAlg ?? SDJwtInstance.DEFAULT_hashAlg;
 
@@ -146,17 +142,6 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
     });
 
     return sdJwt.encodeSDJwt();
-  }
-
-  /**
-   * Validates if the disclosureFrame contains any reserved fields. If so it will throw an error.
-   * @param disclosureFrame
-   * @returns
-   */
-  protected validateReservedFields<T extends ExtendedPayload>(
-    disclosureFrame: DisclosureFrame<T>,
-  ) {
-    return;
   }
 
   public async present<T extends Record<string, unknown>>(

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -34,11 +34,30 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
   }
 
   /**
+   * Issue a sd jwt vc
+   * @param payload 
+   * @param disclosureFrame 
+   * @returns 
+   */
+  issue(
+    payload: SdJwtVcPayload,
+    disclosureFrame?: DisclosureFrame<SdJwtVcPayload>,
+  ): Promise<string> {
+    // validate the disclosure frame
+    try {
+      this.validateReservedFields(disclosureFrame);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    return super.issue(payload, disclosureFrame);
+  }
+
+  /**
    * Validates if the disclosureFrame contains any reserved fields. If so it will throw an error.
    * @param disclosureFrame
    */
   protected validateReservedFields(
-    disclosureFrame: DisclosureFrame<SdJwtVcPayload>,
+    disclosureFrame?: DisclosureFrame<SdJwtVcPayload>,
   ): void {
     //validate disclosureFrame according to https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-08.html#section-3.2.2.2
     if (
@@ -52,7 +71,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
         disclosureFrame._sd as string[]
       ).filter((key) => reservedNames.includes(key));
       if (reservedNamesInDisclosureFrame.length > 0) {
-        throw new SDJWTException('Cannot disclose protected field');
+        throw new SDJWTException(`Cannot disclose protected fields: ${reservedNamesInDisclosureFrame.join(', ')}`);
       }
     }
   }

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -44,13 +44,13 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
     disclosureFrame?: DisclosureFrame<SdJwtVcPayload>,
     options?: {
       header?: object; // This is for customizing the header of the jwt
-      schema?: SchemaObject
-    }
+      schema?: SchemaObject;
+    },
   ): Promise<string> {
     // validate the disclosure frame
     try {
       this.validateReservedFields(disclosureFrame);
-      if (options?.schema) {        
+      if (options?.schema) {
         this.validateSchema(payload, options.schema);
       }
     } catch (error) {
@@ -61,15 +61,17 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
 
   /**
    * Validates the schemas against the provided payload. If e.g. required fields are not set, it will throw an error.
-   * @param payload 
-   * @param schema 
+   * @param payload
+   * @param schema
    */
   private validateSchema(payload: SdJwtVcPayload, schema: SchemaObject) {
     const ajv = new Ajv();
     addFormats(ajv);
-    const validate = ajv.compile(schema);    
-    if (!validate(payload)) {      
-      throw new SDJWTException(`Payload validation failed: ${ajv.errorsText(validate.errors)}`);
+    const validate = ajv.compile(schema);
+    if (!validate(payload)) {
+      throw new SDJWTException(
+        `Payload validation failed: ${ajv.errorsText(validate.errors)}`,
+      );
     }
   }
 

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -35,9 +35,9 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
 
   /**
    * Issue a sd jwt vc
-   * @param payload 
-   * @param disclosureFrame 
-   * @returns 
+   * @param payload
+   * @param disclosureFrame
+   * @returns
    */
   issue(
     payload: SdJwtVcPayload,
@@ -71,7 +71,11 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
         disclosureFrame._sd as string[]
       ).filter((key) => reservedNames.includes(key));
       if (reservedNamesInDisclosureFrame.length > 0) {
-        throw new SDJWTException(`Cannot disclose protected fields: ${reservedNamesInDisclosureFrame.join(', ')}`);
+        throw new SDJWTException(
+          `Cannot disclose protected fields: ${reservedNamesInDisclosureFrame.join(
+            ', ',
+          )}`,
+        );
       }
     }
   }

--- a/packages/sd-jwt-vc/src/test/index.spec.ts
+++ b/packages/sd-jwt-vc/src/test/index.spec.ts
@@ -162,7 +162,7 @@ describe('Revocation', () => {
 
   test('passing a schema but with inconsistent fields', async () => {
     const claims = {
-      firstname: 'John',      
+      firstname: 'John',
     };
     const expectedPayload: SdJwtVcPayload = { iat, iss, vct, ...claims };
     const encodedSdjwt = sdjwt.issue(expectedPayload, undefined, {

--- a/packages/sd-jwt-vc/src/test/index.spec.ts
+++ b/packages/sd-jwt-vc/src/test/index.spec.ts
@@ -159,4 +159,41 @@ describe('Revocation', () => {
   test('test with an expired status list', async () => {
     //TODO: needs to be implemented
   });
+
+  test('passing a schema but with inconsistent fields', async () => {
+    const claims = {
+      firstname: 'John',      
+    };
+    const expectedPayload: SdJwtVcPayload = { iat, iss, vct, ...claims };
+    const encodedSdjwt = sdjwt.issue(expectedPayload, undefined, {
+      schema: {
+        type: 'object',
+        properties: {
+          firstname: { type: 'string' },
+          lastname: { type: 'string' },
+        },
+        required: ['firstname', 'lastname'],
+      },
+    });
+    expect(encodedSdjwt).rejects.toThrowError(/lastname/);
+  });
+
+  test('passing a schema but with consistent fields', async () => {
+    const claims = {
+      firstname: 'John',
+      lastname: 'Doe',
+    };
+    const expectedPayload: SdJwtVcPayload = { iat, iss, vct, ...claims };
+    const encodedSdjwt = sdjwt.issue(expectedPayload, undefined, {
+      schema: {
+        type: 'object',
+        properties: {
+          firstname: { type: 'string' },
+          lastname: { type: 'string' },
+        },
+        required: ['firstname'],
+      },
+    });
+    expect(encodedSdjwt).toBeDefined();
+  });
 });

--- a/packages/sd-jwt-vc/src/test/vct.spec.ts
+++ b/packages/sd-jwt-vc/src/test/vct.spec.ts
@@ -174,22 +174,20 @@ describe('App', () => {
   });
 
   test('VCT Validation with invalid schema', async () => {
-    const claims = {      
+    const claims = {
       lastname: 'Doe',
     };
     const expectedPayload: SdJwtVcPayload = { iat, iss, vct, ...claims };
     const encodedSdjwt = await sdjwt.issue(expectedPayload, undefined, {
       schema: {
         type: 'object',
-        properties: {          
+        properties: {
           lastname: { type: 'string' },
         },
         required: ['lastname'],
       },
     });
-    expect(sdjwt.verify(encodedSdjwt)).rejects.toThrowError(
-      /firstName/
-    );
+    expect(sdjwt.verify(encodedSdjwt)).rejects.toThrowError(/firstName/);
   });
 
   test('VCT Metadata retrieval', async () => {

--- a/packages/sd-jwt-vc/src/test/vct.spec.ts
+++ b/packages/sd-jwt-vc/src/test/vct.spec.ts
@@ -16,7 +16,7 @@ const exampleVctm = {
   schema_uri: 'http://example.com/schema/example',
   //this value could be generated on demand to make it easier when changing the values
   'schema_uri#Integrity':
-    'sha256-48a61b283ded3b55e8d9a9b063327641dc4c53f76bd5daa96c23f232822167ae',
+    'sha256-1fd7c768eabdda5e91855ae6f7042fd2eb4582db128c6c13f773d6a72a71263a',
 };
 
 const restHandlers = [
@@ -47,7 +47,7 @@ const restHandlers = [
           type: 'string',
         },
       },
-      required: ['iss', 'vct'],
+      required: ['iss', 'vct', 'firstName'],
     };
     return HttpResponse.json(res);
   }),
@@ -66,7 +66,7 @@ const restHandlers = [
 
 //this value could be generated on demand to make it easier when changing the values
 const vctIntegrity =
-  'sha256-96bed58130a44af05ae8970aa9caa0bf0135cd15afe721ea29f553394692acef';
+  'sha256-e404c3aa9b730b5cb17a468c0d46c6eb035f83c1621da97644ea40239e3017d6';
 
 const server = setupServer(...restHandlers);
 
@@ -107,10 +107,10 @@ describe('App', () => {
   });
 
   const claims = {
-    firstname: 'John',
+    firstName: 'John',
   };
   const disclosureFrame = {
-    _sd: ['firstname'],
+    _sd: ['firstName'],
   };
 
   beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
@@ -173,6 +173,25 @@ describe('App', () => {
     );
   });
 
+  test('VCT Validation with invalid schema', async () => {
+    const claims = {      
+      lastname: 'Doe',
+    };
+    const expectedPayload: SdJwtVcPayload = { iat, iss, vct, ...claims };
+    const encodedSdjwt = await sdjwt.issue(expectedPayload, undefined, {
+      schema: {
+        type: 'object',
+        properties: {          
+          lastname: { type: 'string' },
+        },
+        required: ['lastname'],
+      },
+    });
+    expect(sdjwt.verify(encodedSdjwt)).rejects.toThrowError(
+      /firstName/
+    );
+  });
+
   test('VCT Metadata retrieval', async () => {
     const expectedPayload: SdJwtVcPayload = {
       iat,
@@ -192,7 +211,7 @@ describe('App', () => {
       name: 'ExampleCredentialType',
       schema_uri: 'http://example.com/schema/example',
       'schema_uri#Integrity':
-        'sha256-48a61b283ded3b55e8d9a9b063327641dc4c53f76bd5daa96c23f232822167ae',
+        'sha256-1fd7c768eabdda5e91855ae6f7042fd2eb4582db128c6c13f773d6a72a71263a',
       vct: 'http://example.com/example',
     });
   });


### PR DESCRIPTION
Closes #248

Adding validation during issuance when a schema is passed. The issue function will not fetch it from the vct, but requires direct passing.

Schema validation during verification was already included

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>