### PR TITLE
fix: add provenance to release step

### DIFF
--- a/.github/workflows/build-test-publish-on-push-cached.yaml
+++ b/.github/workflows/build-test-publish-on-push-cached.yaml
@@ -114,6 +114,7 @@ jobs:
     # needs permissions to write tags to the repository
     permissions:
       contents: write
+      id-token: write
     needs:
       - build
       - test
@@ -125,6 +126,7 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}
       GH_USER: github-actions
       GH_EMAIL: github-actions@github.com
+      NPM_CONFIG_PROVENANCE: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,7 @@ jobs:
     # needs permissions to write tags to the repository
     permissions:
       contents: write
+      id-token: write
     needs:
       - build
       - test
@@ -144,6 +145,7 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}
       GH_USER: github-actions
       GH_EMAIL: github-actions@github.com
+      NPM_CONFIG_PROVENANCE: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
fixes #318

Adding the flag accoding to: https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools

Can not tested before merge, but should be correct. According to lerna this is already supported in v6, we have v8: https://github.com/lerna/lerna/issues/3657

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>