### PR TITLE
fix: correct requiredClaimKeys in sd-jwt kb example to match presented claims

### DIFF
--- a/examples/sd-jwt-example/kb.ts
+++ b/examples/sd-jwt-example/kb.ts
@@ -49,7 +49,7 @@ import { createSignerVerifier, digest, ES256, generateSalt } from './utils';
   );
 
   const verified = await sdjwt.verify(presentedSdJwt, {
-    requiredClaimKeys: ['ssn', 'id'],
+    requiredClaimKeys: ['id'],
     keyBindingNonce: '1234',
   });
   console.log(verified);


### PR DESCRIPTION

  ## Summary
  Fix the SD-JWT key binding example to run without errors.

  ## Problem
  The example was failing with `SDJWTException: Missing required claim
   keys: ssn` because:
  - Only `id` was presented in the SD-JWT
  - But verification required both `ssn` and `id`

  ## Solution
  Changed `requiredClaimKeys` from `['ssn', 'id']` to `['id']` to match the presented claim.

Now the example runs successfully and demonstrates proper SD-JWT verification with key binding.

<img width="484" height="197" alt="KakaoTalk_Photo_2025-10-01-12-22-52" src="https://github.com/user-attachments/assets/9bff7b14-257d-41cd-97b4-21d3a3ba9bcc" />


