### PR TITLE
fix: change repo url from labs to other one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,154 +3,154 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.15.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.15.0...v0.15.1) (2025-08-28)
+## [0.15.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.15.0...v0.15.1) (2025-08-28)
 
 
 ### Bug Fixes
 
-* make iss claim optional in SD-JWT VC payload ([#310](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/310)) ([f6275e3](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f6275e35e66777709321328ba50fec53e5f48c7b))
+* make iss claim optional in SD-JWT VC payload ([#310](https://github.com/openwallet-foundation/sd-jwt-js/issues/310)) ([f6275e3](https://github.com/openwallet-foundation/sd-jwt-js/commit/f6275e35e66777709321328ba50fec53e5f48c7b))
 
 
 
 
 
-# [0.15.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
+# [0.15.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
 
 
 ### Features
 
-* Allows to pass a custom function for the status list JWT validation ([#306](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/306)) ([25e546e](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/25e546e1536178f8ee41b0e1b3836656fd6f48ab))
+* Allows to pass a custom function for the status list JWT validation ([#306](https://github.com/openwallet-foundation/sd-jwt-js/issues/306)) ([25e546e](https://github.com/openwallet-foundation/sd-jwt-js/commit/25e546e1536178f8ee41b0e1b3836656fd6f48ab))
 
 
 
 
 
-## [0.14.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.0...v0.14.1) (2025-08-02)
+## [0.14.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.0...v0.14.1) (2025-08-02)
 
 
 ### Bug Fixes
 
-* claim type ([#300](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/300)) ([3bab5ea](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/3bab5eae69b6ef872209ca00b5593f96b541bc03))
-* pass required options parameter ([#303](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/303)) ([f3aed2d](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f3aed2d54fa4c365c41014c9ba65bf7dd5b7c413))
+* claim type ([#300](https://github.com/openwallet-foundation/sd-jwt-js/issues/300)) ([3bab5ea](https://github.com/openwallet-foundation/sd-jwt-js/commit/3bab5eae69b6ef872209ca00b5593f96b541bc03))
+* pass required options parameter ([#303](https://github.com/openwallet-foundation/sd-jwt-js/issues/303)) ([f3aed2d](https://github.com/openwallet-foundation/sd-jwt-js/commit/f3aed2d54fa4c365c41014c9ba65bf7dd5b7c413))
 
 
 
 
 
-# [0.14.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
-
-
-### Features
-
-* Add Verifier options ([#297](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/297)) ([2a6a367](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2a6a3674f94742f48feaf660056226b1a54145e7))
-
-
-
-
-
-# [0.13.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+# [0.14.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
 
 
 ### Features
 
-* add sha384, sha512 support ([#282](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/282)) ([0a2f20b](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/0a2f20b6383d2356540e7a9cc37748c7b9caced2))
-* fetch VCT Metadata from SD JWT header ([#288](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/288)) ([#294](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/294)) ([f89ba44](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f89ba445aeb57ce342ec76b58a0eb6d0c090a4e9))
+* Add Verifier options ([#297](https://github.com/openwallet-foundation/sd-jwt-js/issues/297)) ([2a6a367](https://github.com/openwallet-foundation/sd-jwt-js/commit/2a6a3674f94742f48feaf660056226b1a54145e7))
 
 
 
 
 
-# [0.12.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
+# [0.13.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+
+
+### Features
+
+* add sha384, sha512 support ([#282](https://github.com/openwallet-foundation/sd-jwt-js/issues/282)) ([0a2f20b](https://github.com/openwallet-foundation/sd-jwt-js/commit/0a2f20b6383d2356540e7a9cc37748c7b9caced2))
+* fetch VCT Metadata from SD JWT header ([#288](https://github.com/openwallet-foundation/sd-jwt-js/issues/288)) ([#294](https://github.com/openwallet-foundation/sd-jwt-js/issues/294)) ([f89ba44](https://github.com/openwallet-foundation/sd-jwt-js/commit/f89ba445aeb57ce342ec76b58a0eb6d0c090a4e9))
+
+
+
+
+
+# [0.12.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
 
 
 ### Bug Fixes
 
-* expose types ([#290](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/290)) ([1b656ac](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/1b656ac21796b715096feae439de6b48442244a9))
+* expose types ([#290](https://github.com/openwallet-foundation/sd-jwt-js/issues/290)) ([1b656ac](https://github.com/openwallet-foundation/sd-jwt-js/commit/1b656ac21796b715096feae439de6b48442244a9))
 
 
 ### Features
 
-* add missing types ([#286](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/286)) ([506b876](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/506b8769ac8e0082ad30544338eace2d0df34294))
+* add missing types ([#286](https://github.com/openwallet-foundation/sd-jwt-js/issues/286)) ([506b876](https://github.com/openwallet-foundation/sd-jwt-js/commit/506b8769ac8e0082ad30544338eace2d0df34294))
 
 
 
 
 
-# [0.11.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
-
-
-### Features
-
-* SD JWT Instances VCT Metadata get separated from verify ([#285](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/285)) ([bc91fd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/bc91fd71f7d721298ad5c08d4379bc870903f65f))
-
-
-
-
-
-# [0.10.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+# [0.11.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
 
 
 ### Features
 
-* fix encoding bug for flattenJSON and generalJSON ([#277](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/277)) ([cc455a6](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/cc455a6f3d431fa59cca1d21dad49daac135d3bc))
+* SD JWT Instances VCT Metadata get separated from verify ([#285](https://github.com/openwallet-foundation/sd-jwt-js/issues/285)) ([bc91fd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/bc91fd71f7d721298ad5c08d4379bc870903f65f))
 
 
 
 
 
-## [0.9.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
+# [0.10.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+
+
+### Features
+
+* fix encoding bug for flattenJSON and generalJSON ([#277](https://github.com/openwallet-foundation/sd-jwt-js/issues/277)) ([cc455a6](https://github.com/openwallet-foundation/sd-jwt-js/commit/cc455a6f3d431fa59cca1d21dad49daac135d3bc))
+
+
+
+
+
+## [0.9.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
 
 
 ### Bug Fixes
 
-* Frame fails when a type with an optional or nullable field is used ([#272](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/272)) ([ed907e3](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/ed907e33c79f140268a03098af1e8c5cc1003ce9))
+* Frame fails when a type with an optional or nullable field is used ([#272](https://github.com/openwallet-foundation/sd-jwt-js/issues/272)) ([ed907e3](https://github.com/openwallet-foundation/sd-jwt-js/commit/ed907e33c79f140268a03098af1e8c5cc1003ce9))
 
 
 
 
 
-## [0.9.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
-
-
-### Bug Fixes
-
-* push changes ([#262](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/262)) ([7a729b7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/7a729b715e315fd7e1770d69002d25f4ec403f41))
-
-
-
-
-
-# [0.9.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
-
-
-### Features
-
-* align type metadata fetching with sd-jwt-vc draft 08 ([#260](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/260)) ([2358c75](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2358c759887ee29b4c35a3ee0e93ebd8e8c26545))
-
-
-
-
-
-# [0.8.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+## [0.9.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
 
 
 ### Bug Fixes
 
-* also push tags when releasing ([#245](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/245)) ([c3f4580](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/c3f4580c6e93856b5eaaad98d12984a7be932639))
-* check if the header includes the string ([#244](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/244)) ([8a48bb5](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/8a48bb57fcf9bbad349f349b0aa1ffd997c86bb2))
-* header alg value in examples ([#251](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/251)) ([974efea](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/974efea1e457689bab92d2fc23aae0ed9fb0eafd))
+* push changes ([#262](https://github.com/openwallet-foundation/sd-jwt-js/issues/262)) ([7a729b7](https://github.com/openwallet-foundation/sd-jwt-js/commit/7a729b715e315fd7e1770d69002d25f4ec403f41))
+
+
+
+
+
+# [0.9.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
 
 
 ### Features
 
-* add jws serialization feature ([#253](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/253)) ([e83b494](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/e83b4946595d043f56647e6cdc98ad34edf0acde))
-* align media type with sd-jwt-vc draft 06 ([#256](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/256)) ([1aa3aea](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/1aa3aea86213e75328975e34d9bf71410fc7a12a))
+* align type metadata fetching with sd-jwt-vc draft 08 ([#260](https://github.com/openwallet-foundation/sd-jwt-js/issues/260)) ([2358c75](https://github.com/openwallet-foundation/sd-jwt-js/commit/2358c759887ee29b4c35a3ee0e93ebd8e8c26545))
 
 
 
 
 
-## [0.7.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
+# [0.8.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+
+
+### Bug Fixes
+
+* also push tags when releasing ([#245](https://github.com/openwallet-foundation/sd-jwt-js/issues/245)) ([c3f4580](https://github.com/openwallet-foundation/sd-jwt-js/commit/c3f4580c6e93856b5eaaad98d12984a7be932639))
+* check if the header includes the string ([#244](https://github.com/openwallet-foundation/sd-jwt-js/issues/244)) ([8a48bb5](https://github.com/openwallet-foundation/sd-jwt-js/commit/8a48bb57fcf9bbad349f349b0aa1ffd997c86bb2))
+* header alg value in examples ([#251](https://github.com/openwallet-foundation/sd-jwt-js/issues/251)) ([974efea](https://github.com/openwallet-foundation/sd-jwt-js/commit/974efea1e457689bab92d2fc23aae0ed9fb0eafd))
+
+
+### Features
+
+* add jws serialization feature ([#253](https://github.com/openwallet-foundation/sd-jwt-js/issues/253)) ([e83b494](https://github.com/openwallet-foundation/sd-jwt-js/commit/e83b4946595d043f56647e6cdc98ad34edf0acde))
+* align media type with sd-jwt-vc draft 06 ([#256](https://github.com/openwallet-foundation/sd-jwt-js/issues/256)) ([1aa3aea](https://github.com/openwallet-foundation/sd-jwt-js/commit/1aa3aea86213e75328975e34d9bf71410fc7a12a))
+
+
+
+
+
+## [0.7.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
 
 **Note:** Version bump only for package @sd-jwt/sd-jwt-vc
 
@@ -158,7 +158,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+## [0.7.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
 
 **Note:** Version bump only for package @sd-jwt/sd-jwt-vc
 
@@ -166,68 +166,68 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.7.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+# [0.7.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
 
 
 ### Bug Fixes
 
-* revert Bump vite from 5.2.9 to 5.2.10 ([#212](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/212)) ([984b598](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/984b598321d2856ce358c8d6348afe96be694388))
+* revert Bump vite from 5.2.9 to 5.2.10 ([#212](https://github.com/openwallet-foundation/sd-jwt-js/issues/212)) ([984b598](https://github.com/openwallet-foundation/sd-jwt-js/commit/984b598321d2856ce358c8d6348afe96be694388))
 
 
 ### Features
 
-* add clone ojbect logic in unpackObj ([#181](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/181)) ([2e92cb3](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2e92cb3abc27f6dbde19c7c016bc1f8ba60f9ff6))
+* add clone ojbect logic in unpackObj ([#181](https://github.com/openwallet-foundation/sd-jwt-js/issues/181)) ([2e92cb3](https://github.com/openwallet-foundation/sd-jwt-js/commit/2e92cb3abc27f6dbde19c7c016bc1f8ba60f9ff6))
 
 
 
 
 
-## [0.6.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
+## [0.6.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
 
 
 ### Bug Fixes
 
-* base64url convention ([#179](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/179)) ([f8db275](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f8db275690dab88000a039838680a3478b3b61ec))
-* incorrect condition on workflow step ([#176](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/176)) ([fec88f0](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/fec88f0c084ee09b3a0c80920782c3efadfc51b1))
-* **sd-jwt-vc:** improve alignment with draft-03 ([#175](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/175)) ([bcd7d6e](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/bcd7d6e40fff938d06425d69297274400ab9e8a6))
+* base64url convention ([#179](https://github.com/openwallet-foundation/sd-jwt-js/issues/179)) ([f8db275](https://github.com/openwallet-foundation/sd-jwt-js/commit/f8db275690dab88000a039838680a3478b3b61ec))
+* incorrect condition on workflow step ([#176](https://github.com/openwallet-foundation/sd-jwt-js/issues/176)) ([fec88f0](https://github.com/openwallet-foundation/sd-jwt-js/commit/fec88f0c084ee09b3a0c80920782c3efadfc51b1))
+* **sd-jwt-vc:** improve alignment with draft-03 ([#175](https://github.com/openwallet-foundation/sd-jwt-js/issues/175)) ([bcd7d6e](https://github.com/openwallet-foundation/sd-jwt-js/commit/bcd7d6e40fff938d06425d69297274400ab9e8a6))
 
 
 ### Features
 
-* set token for deployment ([#174](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/174)) ([d097f8c](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/d097f8c0047abeefd7840d431521da4f7c331804))
+* set token for deployment ([#174](https://github.com/openwallet-foundation/sd-jwt-js/issues/174)) ([d097f8c](https://github.com/openwallet-foundation/sd-jwt-js/commit/d097f8c0047abeefd7840d431521da4f7c331804))
 
 
 
 
 
-# [0.6.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+# [0.6.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
 
 
 ### Bug Fixes
 
-* add missing export ([#159](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/159)) ([f92b3e2](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f92b3e246371a83c51c5450b9bccb04753c58bf4))
-* validate JWT signed other implemenation ([#158](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/158)) ([9f28a26](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/9f28a26214d4112e5ef280e5e754b62e36772328))
+* add missing export ([#159](https://github.com/openwallet-foundation/sd-jwt-js/issues/159)) ([f92b3e2](https://github.com/openwallet-foundation/sd-jwt-js/commit/f92b3e246371a83c51c5450b9bccb04753c58bf4))
+* validate JWT signed other implemenation ([#158](https://github.com/openwallet-foundation/sd-jwt-js/issues/158)) ([9f28a26](https://github.com/openwallet-foundation/sd-jwt-js/commit/9f28a26214d4112e5ef280e5e754b62e36772328))
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([9baa93e](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/9baa93efb612ee2fe73c5872766cbc37e541c4dc))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([9baa93e](https://github.com/openwallet-foundation/sd-jwt-js/commit/9baa93efb612ee2fe73c5872766cbc37e541c4dc))
 
 
 
 
 
-# [0.5.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
+# [0.5.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
 
 
 ### Bug Fixes
 
-* validate JWT signed other implemenation ([#158](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/158)) ([a0c1ddb](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/a0c1ddbb4c3785d03fc7302183f9c13e3c3fd955))
+* validate JWT signed other implemenation ([#158](https://github.com/openwallet-foundation/sd-jwt-js/issues/158)) ([a0c1ddb](https://github.com/openwallet-foundation/sd-jwt-js/commit/a0c1ddbb4c3785d03fc7302183f9c13e3c3fd955))
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
 
 
 
@@ -238,35 +238,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* add public param ([#92](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/92)) ([c3d7311](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/c3d7311551693bddaf8b2661f0e1b295f8d3e00c))
-* add publish config ([#93](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
-* add the payload that is required ([6c53580](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/6c53580d12e4361c40435b90628302749fa32b1c))
-* adding myself to the contributors page ([#90](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/90)) ([3096388](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/3096388a196be7050ffb7a87e91980e45a24e304))
-* change name in packages ([832554d](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/832554d56c44d46677a55d5c1f76ea5414335931))
-* change SDJwtPayload to SdJwtPayload ([9f06ef7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/9f06ef7bd31a1dff4e9bf988e425200a5e1aa82d))
-* ci publish action ([#89](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/89)) ([fedec8d](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/fedec8d8552300ab26229a5c94031086ff02aaec))
-* convert any usage into  or typed version ([#80](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/80)) ([de4df54](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/de4df54f2a0a77fdbf97e10abac555a98e70c6e0))
-* format file ([28202b2](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/28202b20daf80225cea0f5415a14b623276c6188))
-* implement kbverify function ([#127](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/127)) ([e5609f2](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/e5609f26fab8c4991d3bd6c36066a95a30cfb972))
-* make sdjwt instance non abstract ([#122](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/122)) ([e85aae8](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/e85aae89910f5d9468e29ef14ef3b3d3215b86fd))
-* the bytes of the output of the hash function must be base64url-encoded. ([#57](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/57)) ([025786b](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/025786bd76415195e5daff0c5f2270ece31bd963))
-* update example code ([84a8d36](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/84a8d365508fffcd34d72149f9462767a116c4f5))
-* update type of credential ([63d5ebb](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/63d5ebb4e3e5dd34ae8f82b2ef890a9b2647654f))
-* upload code cov ([#75](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/75)) ([1b24ff9](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/1b24ff9fb57e0ddd480892cba09e01e70d3f1cdc))
+* add public param ([#92](https://github.com/openwallet-foundation/sd-jwt-js/issues/92)) ([c3d7311](https://github.com/openwallet-foundation/sd-jwt-js/commit/c3d7311551693bddaf8b2661f0e1b295f8d3e00c))
+* add publish config ([#93](https://github.com/openwallet-foundation/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
+* add the payload that is required ([6c53580](https://github.com/openwallet-foundation/sd-jwt-js/commit/6c53580d12e4361c40435b90628302749fa32b1c))
+* adding myself to the contributors page ([#90](https://github.com/openwallet-foundation/sd-jwt-js/issues/90)) ([3096388](https://github.com/openwallet-foundation/sd-jwt-js/commit/3096388a196be7050ffb7a87e91980e45a24e304))
+* change name in packages ([832554d](https://github.com/openwallet-foundation/sd-jwt-js/commit/832554d56c44d46677a55d5c1f76ea5414335931))
+* change SDJwtPayload to SdJwtPayload ([9f06ef7](https://github.com/openwallet-foundation/sd-jwt-js/commit/9f06ef7bd31a1dff4e9bf988e425200a5e1aa82d))
+* ci publish action ([#89](https://github.com/openwallet-foundation/sd-jwt-js/issues/89)) ([fedec8d](https://github.com/openwallet-foundation/sd-jwt-js/commit/fedec8d8552300ab26229a5c94031086ff02aaec))
+* convert any usage into  or typed version ([#80](https://github.com/openwallet-foundation/sd-jwt-js/issues/80)) ([de4df54](https://github.com/openwallet-foundation/sd-jwt-js/commit/de4df54f2a0a77fdbf97e10abac555a98e70c6e0))
+* format file ([28202b2](https://github.com/openwallet-foundation/sd-jwt-js/commit/28202b20daf80225cea0f5415a14b623276c6188))
+* implement kbverify function ([#127](https://github.com/openwallet-foundation/sd-jwt-js/issues/127)) ([e5609f2](https://github.com/openwallet-foundation/sd-jwt-js/commit/e5609f26fab8c4991d3bd6c36066a95a30cfb972))
+* make sdjwt instance non abstract ([#122](https://github.com/openwallet-foundation/sd-jwt-js/issues/122)) ([e85aae8](https://github.com/openwallet-foundation/sd-jwt-js/commit/e85aae89910f5d9468e29ef14ef3b3d3215b86fd))
+* the bytes of the output of the hash function must be base64url-encoded. ([#57](https://github.com/openwallet-foundation/sd-jwt-js/issues/57)) ([025786b](https://github.com/openwallet-foundation/sd-jwt-js/commit/025786bd76415195e5daff0c5f2270ece31bd963))
+* update example code ([84a8d36](https://github.com/openwallet-foundation/sd-jwt-js/commit/84a8d365508fffcd34d72149f9462767a116c4f5))
+* update type of credential ([63d5ebb](https://github.com/openwallet-foundation/sd-jwt-js/commit/63d5ebb4e3e5dd34ae8f82b2ef890a9b2647654f))
+* upload code cov ([#75](https://github.com/openwallet-foundation/sd-jwt-js/issues/75)) ([1b24ff9](https://github.com/openwallet-foundation/sd-jwt-js/commit/1b24ff9fb57e0ddd480892cba09e01e70d3f1cdc))
 
 
 ### Features
 
-* add jwk type ([#130](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/130)) ([8ce255a](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/8ce255a64b0940e92e647aa544bf5990b48279b7))
-* add new package for sd-jwt-vc ([ed99188](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/ed99188f13184d58db64b4211e39fb67f3f78cb5))
-* Apply lerna to move src to core ([#67](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/67)) ([49e272b](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/49e272b6b51c5226e22732c469e566fd3c14c57c))
-* calcuate sd_hash in kb JWT ([#117](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/117)) ([3415550](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/3415550fbcd99f97babff442a4928cc827c5c9cc))
-* checking kb header value ([#133](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/133)) ([cd2991b](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/cd2991b88a0522e39251c5ca2b67593130baa585))
-* create kb jwt when present all ([#129](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/129)) ([72ed1ad](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/72ed1ad64b850876ba3b5d5e5df6128471fb44ac))
-* es crypto features to nodejs and browser ([#106](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/106)) ([3ba74e9](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/3ba74e936dbc39698d47c6c8c1da956430e937f8))
-* fix async handling in jwt verify ([#131](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/131)) ([76cb930](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/76cb93021dd62c241c87656975f74dd44b3766cf))
-* fixing exclude _sd_alg when no disclosure ([#120](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/120)) ([dcaf1f6](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/dcaf1f6fad3289ea7cbe0f3f410fdc15c0f77fda))
-* restore rsa type in JWK ([#137](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/137)) ([fe0d8f6](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/fe0d8f6a3249dfea27b08f82165555de389efe1d))
-* Support lower version of nodejs in crypto ([#48](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/48)) ([6aa790c](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/6aa790c0bbb547608d88a6ae3809ffa6cae3cf73))
-* update present example ([#142](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/142)) ([f9ae804](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f9ae80418c4a571d7e8550817fe5ca59355c9746))
-* use tsup as a bundler ([#62](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/62)) ([dc61be9](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/dc61be9df1d9b1a3184cb547e2c2b88e23b1b6fd))
+* add jwk type ([#130](https://github.com/openwallet-foundation/sd-jwt-js/issues/130)) ([8ce255a](https://github.com/openwallet-foundation/sd-jwt-js/commit/8ce255a64b0940e92e647aa544bf5990b48279b7))
+* add new package for sd-jwt-vc ([ed99188](https://github.com/openwallet-foundation/sd-jwt-js/commit/ed99188f13184d58db64b4211e39fb67f3f78cb5))
+* Apply lerna to move src to core ([#67](https://github.com/openwallet-foundation/sd-jwt-js/issues/67)) ([49e272b](https://github.com/openwallet-foundation/sd-jwt-js/commit/49e272b6b51c5226e22732c469e566fd3c14c57c))
+* calcuate sd_hash in kb JWT ([#117](https://github.com/openwallet-foundation/sd-jwt-js/issues/117)) ([3415550](https://github.com/openwallet-foundation/sd-jwt-js/commit/3415550fbcd99f97babff442a4928cc827c5c9cc))
+* checking kb header value ([#133](https://github.com/openwallet-foundation/sd-jwt-js/issues/133)) ([cd2991b](https://github.com/openwallet-foundation/sd-jwt-js/commit/cd2991b88a0522e39251c5ca2b67593130baa585))
+* create kb jwt when present all ([#129](https://github.com/openwallet-foundation/sd-jwt-js/issues/129)) ([72ed1ad](https://github.com/openwallet-foundation/sd-jwt-js/commit/72ed1ad64b850876ba3b5d5e5df6128471fb44ac))
+* es crypto features to nodejs and browser ([#106](https://github.com/openwallet-foundation/sd-jwt-js/issues/106)) ([3ba74e9](https://github.com/openwallet-foundation/sd-jwt-js/commit/3ba74e936dbc39698d47c6c8c1da956430e937f8))
+* fix async handling in jwt verify ([#131](https://github.com/openwallet-foundation/sd-jwt-js/issues/131)) ([76cb930](https://github.com/openwallet-foundation/sd-jwt-js/commit/76cb93021dd62c241c87656975f74dd44b3766cf))
+* fixing exclude _sd_alg when no disclosure ([#120](https://github.com/openwallet-foundation/sd-jwt-js/issues/120)) ([dcaf1f6](https://github.com/openwallet-foundation/sd-jwt-js/commit/dcaf1f6fad3289ea7cbe0f3f410fdc15c0f77fda))
+* restore rsa type in JWK ([#137](https://github.com/openwallet-foundation/sd-jwt-js/issues/137)) ([fe0d8f6](https://github.com/openwallet-foundation/sd-jwt-js/commit/fe0d8f6a3249dfea27b08f82165555de389efe1d))
+* Support lower version of nodejs in crypto ([#48](https://github.com/openwallet-foundation/sd-jwt-js/issues/48)) ([6aa790c](https://github.com/openwallet-foundation/sd-jwt-js/commit/6aa790c0bbb547608d88a6ae3809ffa6cae3cf73))
+* update present example ([#142](https://github.com/openwallet-foundation/sd-jwt-js/issues/142)) ([f9ae804](https://github.com/openwallet-foundation/sd-jwt-js/commit/f9ae80418c4a571d7e8550817fe5ca59355c9746))
+* use tsup as a bundler ([#62](https://github.com/openwallet-foundation/sd-jwt-js/issues/62)) ([dc61be9](https://github.com/openwallet-foundation/sd-jwt-js/commit/dc61be9df1d9b1a3184cb547e2c2b88e23b1b6fd))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 
 In short, when you submit code changes, your submissions are understood to be under the same [Apache 2.0 License](http://www.apache.org/licenses/) that covers the project. Feel free to contact the maintainers if that's a concern.
 
-## Report bugs using Github's [issues](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues)
+## Report bugs using Github's [issues](https://github.com/openwallet-foundation/sd-jwt-js/issues)
 
 We use GitHub issues to track public bugs. Report a bug by opening a new issue it's that easy!
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-![Coverage](https://img.shields.io/codecov/c/github/openwallet-foundation-labs/sd-jwt-js)
-![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![Coverage](https://img.shields.io/codecov/c/github/openwallet-foundation/sd-jwt-js)
+![License](https://img.shields.io/github/license/openwallet-foundation/sd-jwt-js.svg)
 ![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Fcore)
 ![NPM-Downloads](https://img.shields.io/endpoint?&url=https://runkit.io/lukasjhan/npm-combined-downloads/1.0.0?packages=@sd-jwt/core,@sd-jwt/types,@sd-jwt/decode,@sd-jwt/utils,@sd-jwt/sd-jwt-vc,@sd-jwt/crypto-nodejs,@sd-jwt/crypto-browser,@sd-jwt/hash,@sd-jwt/present&label=npm%20downloads&color=ff7724)
-![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
-![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation/sd-jwt-js)
 
 # SD-JWT Implementation in JavaScript (TypeScript)
 
@@ -88,7 +88,7 @@ pnpm test
 
 We use [Vitest](https://vitest.dev/) for our testing framework. Ensure you have written tests for all new features.
 
-We also use [CodeCov](https://app.codecov.io/gh/openwallet-foundation-labs/sd-jwt-js) for our testing coverage. You can check the details of coverage of each package
+We also use [CodeCov](https://app.codecov.io/gh/openwallet-foundation/sd-jwt-js) for our testing coverage. You can check the details of coverage of each package
 
 ## Security
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -120,21 +120,21 @@
         >
         |
         <a
-          href="https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples"
+          href="https://github.com/openwallet-foundation/sd-jwt-js/tree/main/examples"
           class="text-blue-700 hover:underline"
           target="_blank"
           >Examples</a
         >
         |
         <a 
-          href="https://github.com/openwallet-foundation-labs/sd-jwt-js" 
+          href="https://github.com/openwallet-foundation/sd-jwt-js" 
           class="text-blue-700 hover:underline"
           target="_blank"
           >GitHub</a>
       </div>
       <h2 class="text-2xl font-bold mb-4">Architecture & Core Concept</h2>
       <img
-        src="https://raw.githubusercontent.com/openwallet-foundation-labs/sd-jwt-js/main/images/diagram.png"
+        src="https://raw.githubusercontent.com/openwallet-foundation/sd-jwt-js/main/images/diagram.png"
         class="img-responsive img-centered width-100 height-100"
         alt="SD JWT diagram"
       />

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "pnpm": ">=9"
   },
   "repository": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js"
   },
   "author": "Lukas.J.Han <lukas.j.han@gmail.com>",
   "homepage": "https://sdjwt.js.org",
   "bugs": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/browser-crypto/CHANGELOG.md
+++ b/packages/browser-crypto/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.15.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
+# [0.15.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.14.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
+# [0.14.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.13.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+# [0.13.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.12.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
+# [0.12.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.11.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
+# [0.11.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.10.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+# [0.10.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -51,7 +51,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
+## [0.9.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
+## [0.9.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.9.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
+# [0.9.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.8.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+# [0.8.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
+## [0.7.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+## [0.7.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -99,7 +99,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.7.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+# [0.7.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -107,7 +107,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.6.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
+## [0.6.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -115,7 +115,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.6.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+# [0.6.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
 
 **Note:** Version bump only for package @sd-jwt/crypto-browser
 
@@ -123,12 +123,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.5.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
+# [0.5.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
 
 
 
@@ -139,4 +139,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* es crypto features to nodejs and browser ([#106](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/106)) ([3ba74e9](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/3ba74e936dbc39698d47c6c8c1da956430e937f8))
+* es crypto features to nodejs and browser ([#106](https://github.com/openwallet-foundation/sd-jwt-js/issues/106)) ([3ba74e9](https://github.com/openwallet-foundation/sd-jwt-js/commit/3ba74e936dbc39698d47c6c8c1da956430e937f8))

--- a/packages/browser-crypto/README.md
+++ b/packages/browser-crypto/README.md
@@ -1,7 +1,7 @@
-![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![License](https://img.shields.io/github/license/openwallet-foundation/sd-jwt-js.svg)
 ![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Fcrypto-browser)
-![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
-![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation/sd-jwt-js)
 
 # SD-JWT Implementation in JavaScript (TypeScript)
 
@@ -11,7 +11,7 @@
 
 Browser Crypto support for SD JWT
 
-Check the detail description in our github [repo](https://github.com/openwallet-foundation-labs/sd-jwt-js).
+Check the detail description in our github [repo](https://github.com/openwallet-foundation/sd-jwt-js).
 
 ### Installation
 
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/browser-crypto/package.json
+++ b/packages/browser-crypto/package.json
@@ -24,12 +24,12 @@
     "sd-jwt-vc"
   ],
   "repository": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js"
   },
   "author": "Lukas.J.Han <lukas.j.han@gmail.com>",
-  "homepage": "https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki",
+  "homepage": "https://github.com/openwallet-foundation/sd-jwt-js/wiki",
   "bugs": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.15.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
+# [0.15.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
 
 **Note:** Version bump only for package @sd-jwt/core
 
@@ -11,110 +11,67 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.0...v0.14.1) (2025-08-02)
+## [0.14.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.0...v0.14.1) (2025-08-02)
 
 
 ### Bug Fixes
 
-* pass required options parameter ([#303](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/303)) ([f3aed2d](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f3aed2d54fa4c365c41014c9ba65bf7dd5b7c413))
+* pass required options parameter ([#303](https://github.com/openwallet-foundation/sd-jwt-js/issues/303)) ([f3aed2d](https://github.com/openwallet-foundation/sd-jwt-js/commit/f3aed2d54fa4c365c41014c9ba65bf7dd5b7c413))
 
 
 
 
 
-# [0.14.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
-
-
-### Features
-
-* Add Verifier options ([#297](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/297)) ([2a6a367](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2a6a3674f94742f48feaf660056226b1a54145e7))
-
-
-
-
-
-# [0.13.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
-
-**Note:** Version bump only for package @sd-jwt/core
-
-
-
-
-
-# [0.12.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
-
-**Note:** Version bump only for package @sd-jwt/core
-
-
-
-
-
-# [0.11.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
+# [0.14.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
 
 
 ### Features
 
-* SD JWT Instances VCT Metadata get separated from verify ([#285](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/285)) ([bc91fd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/bc91fd71f7d721298ad5c08d4379bc870903f65f))
+* Add Verifier options ([#297](https://github.com/openwallet-foundation/sd-jwt-js/issues/297)) ([2a6a367](https://github.com/openwallet-foundation/sd-jwt-js/commit/2a6a3674f94742f48feaf660056226b1a54145e7))
 
 
 
 
 
-# [0.10.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+# [0.13.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+
+**Note:** Version bump only for package @sd-jwt/core
+
+
+
+
+
+# [0.12.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
+
+**Note:** Version bump only for package @sd-jwt/core
+
+
+
+
+
+# [0.11.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
 
 
 ### Features
 
-* fix encoding bug for flattenJSON and generalJSON ([#277](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/277)) ([cc455a6](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/cc455a6f3d431fa59cca1d21dad49daac135d3bc))
+* SD JWT Instances VCT Metadata get separated from verify ([#285](https://github.com/openwallet-foundation/sd-jwt-js/issues/285)) ([bc91fd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/bc91fd71f7d721298ad5c08d4379bc870903f65f))
 
 
 
 
 
-## [0.9.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
-
-**Note:** Version bump only for package @sd-jwt/core
-
-
-
-
-
-## [0.9.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
-
-**Note:** Version bump only for package @sd-jwt/core
-
-
-
-
-
-# [0.9.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
-
-**Note:** Version bump only for package @sd-jwt/core
-
-
-
-
-
-# [0.8.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+# [0.10.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
 
 
 ### Features
 
-* add jws serialization feature ([#253](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/253)) ([e83b494](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/e83b4946595d043f56647e6cdc98ad34edf0acde))
+* fix encoding bug for flattenJSON and generalJSON ([#277](https://github.com/openwallet-foundation/sd-jwt-js/issues/277)) ([cc455a6](https://github.com/openwallet-foundation/sd-jwt-js/commit/cc455a6f3d431fa59cca1d21dad49daac135d3bc))
 
 
 
 
 
-## [0.7.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
-
-**Note:** Version bump only for package @sd-jwt/core
-
-
-
-
-
-## [0.7.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+## [0.9.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
 
 **Note:** Version bump only for package @sd-jwt/core
 
@@ -122,7 +79,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.7.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+## [0.9.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
 
 **Note:** Version bump only for package @sd-jwt/core
 
@@ -130,18 +87,61 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.6.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
+# [0.9.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
+
+**Note:** Version bump only for package @sd-jwt/core
+
+
+
+
+
+# [0.8.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+
+
+### Features
+
+* add jws serialization feature ([#253](https://github.com/openwallet-foundation/sd-jwt-js/issues/253)) ([e83b494](https://github.com/openwallet-foundation/sd-jwt-js/commit/e83b4946595d043f56647e6cdc98ad34edf0acde))
+
+
+
+
+
+## [0.7.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
+
+**Note:** Version bump only for package @sd-jwt/core
+
+
+
+
+
+## [0.7.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+
+**Note:** Version bump only for package @sd-jwt/core
+
+
+
+
+
+# [0.7.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+
+**Note:** Version bump only for package @sd-jwt/core
+
+
+
+
+
+## [0.6.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
 
 
 ### Bug Fixes
 
-* base64url convention ([#179](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/179)) ([f8db275](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f8db275690dab88000a039838680a3478b3b61ec))
+* base64url convention ([#179](https://github.com/openwallet-foundation/sd-jwt-js/issues/179)) ([f8db275](https://github.com/openwallet-foundation/sd-jwt-js/commit/f8db275690dab88000a039838680a3478b3b61ec))
 
 
 
 
 
-# [0.6.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+# [0.6.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
 
 **Note:** Version bump only for package @sd-jwt/core
 
@@ -149,17 +149,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.5.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
+# [0.5.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
 
 
 ### Bug Fixes
 
-* validate JWT signed other implemenation ([#158](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/158)) ([a0c1ddb](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/a0c1ddbb4c3785d03fc7302183f9c13e3c3fd955))
+* validate JWT signed other implemenation ([#158](https://github.com/openwallet-foundation/sd-jwt-js/issues/158)) ([a0c1ddb](https://github.com/openwallet-foundation/sd-jwt-js/commit/a0c1ddbb4c3785d03fc7302183f9c13e3c3fd955))
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
 
 
 
@@ -170,21 +170,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* add publish config ([#93](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
-* add the payload that is required ([6c53580](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/6c53580d12e4361c40435b90628302749fa32b1c))
-* change SDJwtPayload to SdJwtPayload ([9f06ef7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/9f06ef7bd31a1dff4e9bf988e425200a5e1aa82d))
-* convert any usage into  or typed version ([#80](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/80)) ([de4df54](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/de4df54f2a0a77fdbf97e10abac555a98e70c6e0))
-* implement kbverify function ([#127](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/127)) ([e5609f2](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/e5609f26fab8c4991d3bd6c36066a95a30cfb972))
-* make sdjwt instance non abstract ([#122](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/122)) ([e85aae8](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/e85aae89910f5d9468e29ef14ef3b3d3215b86fd))
+* add publish config ([#93](https://github.com/openwallet-foundation/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
+* add the payload that is required ([6c53580](https://github.com/openwallet-foundation/sd-jwt-js/commit/6c53580d12e4361c40435b90628302749fa32b1c))
+* change SDJwtPayload to SdJwtPayload ([9f06ef7](https://github.com/openwallet-foundation/sd-jwt-js/commit/9f06ef7bd31a1dff4e9bf988e425200a5e1aa82d))
+* convert any usage into  or typed version ([#80](https://github.com/openwallet-foundation/sd-jwt-js/issues/80)) ([de4df54](https://github.com/openwallet-foundation/sd-jwt-js/commit/de4df54f2a0a77fdbf97e10abac555a98e70c6e0))
+* implement kbverify function ([#127](https://github.com/openwallet-foundation/sd-jwt-js/issues/127)) ([e5609f2](https://github.com/openwallet-foundation/sd-jwt-js/commit/e5609f26fab8c4991d3bd6c36066a95a30cfb972))
+* make sdjwt instance non abstract ([#122](https://github.com/openwallet-foundation/sd-jwt-js/issues/122)) ([e85aae8](https://github.com/openwallet-foundation/sd-jwt-js/commit/e85aae89910f5d9468e29ef14ef3b3d3215b86fd))
 
 
 ### Features
 
-* add jwk type ([#130](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/130)) ([8ce255a](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/8ce255a64b0940e92e647aa544bf5990b48279b7))
-* add new package for sd-jwt-vc ([ed99188](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/ed99188f13184d58db64b4211e39fb67f3f78cb5))
-* Apply lerna to move src to core ([#67](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/67)) ([49e272b](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/49e272b6b51c5226e22732c469e566fd3c14c57c))
-* calcuate sd_hash in kb JWT ([#117](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/117)) ([3415550](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/3415550fbcd99f97babff442a4928cc827c5c9cc))
-* checking kb header value ([#133](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/133)) ([cd2991b](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/cd2991b88a0522e39251c5ca2b67593130baa585))
-* create kb jwt when present all ([#129](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/129)) ([72ed1ad](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/72ed1ad64b850876ba3b5d5e5df6128471fb44ac))
-* fix async handling in jwt verify ([#131](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/131)) ([76cb930](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/76cb93021dd62c241c87656975f74dd44b3766cf))
-* fixing exclude _sd_alg when no disclosure ([#120](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/120)) ([dcaf1f6](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/dcaf1f6fad3289ea7cbe0f3f410fdc15c0f77fda))
+* add jwk type ([#130](https://github.com/openwallet-foundation/sd-jwt-js/issues/130)) ([8ce255a](https://github.com/openwallet-foundation/sd-jwt-js/commit/8ce255a64b0940e92e647aa544bf5990b48279b7))
+* add new package for sd-jwt-vc ([ed99188](https://github.com/openwallet-foundation/sd-jwt-js/commit/ed99188f13184d58db64b4211e39fb67f3f78cb5))
+* Apply lerna to move src to core ([#67](https://github.com/openwallet-foundation/sd-jwt-js/issues/67)) ([49e272b](https://github.com/openwallet-foundation/sd-jwt-js/commit/49e272b6b51c5226e22732c469e566fd3c14c57c))
+* calcuate sd_hash in kb JWT ([#117](https://github.com/openwallet-foundation/sd-jwt-js/issues/117)) ([3415550](https://github.com/openwallet-foundation/sd-jwt-js/commit/3415550fbcd99f97babff442a4928cc827c5c9cc))
+* checking kb header value ([#133](https://github.com/openwallet-foundation/sd-jwt-js/issues/133)) ([cd2991b](https://github.com/openwallet-foundation/sd-jwt-js/commit/cd2991b88a0522e39251c5ca2b67593130baa585))
+* create kb jwt when present all ([#129](https://github.com/openwallet-foundation/sd-jwt-js/issues/129)) ([72ed1ad](https://github.com/openwallet-foundation/sd-jwt-js/commit/72ed1ad64b850876ba3b5d5e5df6128471fb44ac))
+* fix async handling in jwt verify ([#131](https://github.com/openwallet-foundation/sd-jwt-js/issues/131)) ([76cb930](https://github.com/openwallet-foundation/sd-jwt-js/commit/76cb93021dd62c241c87656975f74dd44b3766cf))
+* fixing exclude _sd_alg when no disclosure ([#120](https://github.com/openwallet-foundation/sd-jwt-js/issues/120)) ([dcaf1f6](https://github.com/openwallet-foundation/sd-jwt-js/commit/dcaf1f6fad3289ea7cbe0f3f410fdc15c0f77fda))

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,7 +1,7 @@
-![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![License](https://img.shields.io/github/license/openwallet-foundation/sd-jwt-js.svg)
 ![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Fcore)
-![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
-![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation/sd-jwt-js)
 
 # SD-JWT Implementation in JavaScript (TypeScript)
 
@@ -11,7 +11,7 @@
 
 Core library for selective disclosure JWTs
 
-Check the detail description in our github [repo](https://github.com/openwallet-foundation-labs/sd-jwt-js).
+Check the detail description in our github [repo](https://github.com/openwallet-foundation/sd-jwt-js).
 
 ### Installation
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,12 +28,12 @@
     "node": ">=18"
   },
   "repository": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js"
   },
   "author": "Lukas.J.Han <lukas.j.han@gmail.com>",
-  "homepage": "https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki",
+  "homepage": "https://github.com/openwallet-foundation/sd-jwt-js/wiki",
   "bugs": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/decode/CHANGELOG.md
+++ b/packages/decode/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.15.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
+# [0.15.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.14.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
+# [0.14.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.13.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+# [0.13.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.12.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
+# [0.12.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.11.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
+# [0.11.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.10.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+# [0.10.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -51,7 +51,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
+## [0.9.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
+## [0.9.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.9.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
+# [0.9.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.8.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+# [0.8.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
+## [0.7.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+## [0.7.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -99,29 +99,29 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.7.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+# [0.7.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
 
 
 ### Features
 
-* add clone ojbect logic in unpackObj ([#181](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/181)) ([2e92cb3](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2e92cb3abc27f6dbde19c7c016bc1f8ba60f9ff6))
+* add clone ojbect logic in unpackObj ([#181](https://github.com/openwallet-foundation/sd-jwt-js/issues/181)) ([2e92cb3](https://github.com/openwallet-foundation/sd-jwt-js/commit/2e92cb3abc27f6dbde19c7c016bc1f8ba60f9ff6))
 
 
 
 
 
-## [0.6.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
+## [0.6.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
 
 
 ### Bug Fixes
 
-* base64url convention ([#179](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/179)) ([f8db275](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f8db275690dab88000a039838680a3478b3b61ec))
+* base64url convention ([#179](https://github.com/openwallet-foundation/sd-jwt-js/issues/179)) ([f8db275](https://github.com/openwallet-foundation/sd-jwt-js/commit/f8db275690dab88000a039838680a3478b3b61ec))
 
 
 
 
 
-# [0.6.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+# [0.6.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
 
 **Note:** Version bump only for package @sd-jwt/decode
 
@@ -129,12 +129,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.5.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
+# [0.5.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
 
 
 
@@ -145,7 +145,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* add publish config ([#93](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
-* change SDJwtPayload to SdJwtPayload ([9f06ef7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/9f06ef7bd31a1dff4e9bf988e425200a5e1aa82d))
-* convert any usage into  or typed version ([#80](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/80)) ([de4df54](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/de4df54f2a0a77fdbf97e10abac555a98e70c6e0))
-* make sdjwt instance non abstract ([#122](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/122)) ([e85aae8](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/e85aae89910f5d9468e29ef14ef3b3d3215b86fd))
+* add publish config ([#93](https://github.com/openwallet-foundation/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
+* change SDJwtPayload to SdJwtPayload ([9f06ef7](https://github.com/openwallet-foundation/sd-jwt-js/commit/9f06ef7bd31a1dff4e9bf988e425200a5e1aa82d))
+* convert any usage into  or typed version ([#80](https://github.com/openwallet-foundation/sd-jwt-js/issues/80)) ([de4df54](https://github.com/openwallet-foundation/sd-jwt-js/commit/de4df54f2a0a77fdbf97e10abac555a98e70c6e0))
+* make sdjwt instance non abstract ([#122](https://github.com/openwallet-foundation/sd-jwt-js/issues/122)) ([e85aae8](https://github.com/openwallet-foundation/sd-jwt-js/commit/e85aae89910f5d9468e29ef14ef3b3d3215b86fd))

--- a/packages/decode/README.md
+++ b/packages/decode/README.md
@@ -1,7 +1,7 @@
-![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![License](https://img.shields.io/github/license/openwallet-foundation/sd-jwt-js.svg)
 ![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Fdecode)
-![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
-![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation/sd-jwt-js)
 
 # SD-JWT Implementation in JavaScript (TypeScript)
 
@@ -11,7 +11,7 @@
 
 Decode SD JWT into objects
 
-Check the detail description in our github [repo](https://github.com/openwallet-foundation-labs/sd-jwt-js).
+Check the detail description in our github [repo](https://github.com/openwallet-foundation/sd-jwt-js).
 
 ### Installation
 
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/decode/package.json
+++ b/packages/decode/package.json
@@ -27,12 +27,12 @@
     "node": ">=18"
   },
   "repository": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js"
   },
   "author": "Lukas.J.Han <lukas.j.han@gmail.com>",
-  "homepage": "https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki",
+  "homepage": "https://github.com/openwallet-foundation/sd-jwt-js/wiki",
   "bugs": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/hash/CHANGELOG.md
+++ b/packages/hash/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.15.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
+# [0.15.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.14.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
+# [0.14.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -19,26 +19,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.13.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+# [0.13.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
 
 
 ### Features
 
-* add sha384, sha512 support ([#282](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/282)) ([0a2f20b](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/0a2f20b6383d2356540e7a9cc37748c7b9caced2))
+* add sha384, sha512 support ([#282](https://github.com/openwallet-foundation/sd-jwt-js/issues/282)) ([0a2f20b](https://github.com/openwallet-foundation/sd-jwt-js/commit/0a2f20b6383d2356540e7a9cc37748c7b9caced2))
 
 
 
 
 
-# [0.12.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
-
-**Note:** Version bump only for package @sd-jwt/hash
-
-
-
-
-
-# [0.11.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
+# [0.12.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -46,7 +38,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.10.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+# [0.11.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -54,7 +46,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
+# [0.10.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -62,7 +54,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
+## [0.9.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -70,7 +62,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.9.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
+## [0.9.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -78,7 +70,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.8.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+# [0.9.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -86,7 +78,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
+# [0.8.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -94,7 +86,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+## [0.7.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -102,7 +94,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.7.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+## [0.7.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -110,7 +102,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.6.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
+# [0.7.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -118,7 +110,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.6.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+## [0.6.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
 
 **Note:** Version bump only for package @sd-jwt/hash
 
@@ -126,12 +118,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.5.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
+# [0.6.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+
+**Note:** Version bump only for package @sd-jwt/hash
+
+
+
+
+
+# [0.5.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
 
 
 
@@ -142,4 +142,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* add publish config ([#93](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
+* add publish config ([#93](https://github.com/openwallet-foundation/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))

--- a/packages/hash/README.md
+++ b/packages/hash/README.md
@@ -1,7 +1,7 @@
-![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![License](https://img.shields.io/github/license/openwallet-foundation/sd-jwt-js.svg)
 ![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Fhash)
-![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
-![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation/sd-jwt-js)
 
 # SD-JWT Implementation in JavaScript (TypeScript)
 
@@ -11,7 +11,7 @@
 
 SHA-256 support for SD JWT
 
-Check the detail description in our github [repo](https://github.com/openwallet-foundation-labs/sd-jwt-js).
+Check the detail description in our github [repo](https://github.com/openwallet-foundation/sd-jwt-js).
 
 ### Installation
 
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/hash/package.json
+++ b/packages/hash/package.json
@@ -28,12 +28,12 @@
     "node": ">=18"
   },
   "repository": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js"
   },
   "author": "Lukas.J.Han <lukas.j.han@gmail.com>",
-  "homepage": "https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki",
+  "homepage": "https://github.com/openwallet-foundation/sd-jwt-js/wiki",
   "bugs": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/jwt-status-list/CHANGELOG.md
+++ b/packages/jwt-status-list/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.15.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
+# [0.15.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.14.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
+# [0.14.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.13.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+# [0.13.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.12.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
+# [0.12.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.11.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
+# [0.11.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.10.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+# [0.10.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -51,7 +51,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
+## [0.9.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
+## [0.9.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.9.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
+# [0.9.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.8.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+# [0.8.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
+## [0.7.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+## [0.7.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list
 
@@ -99,6 +99,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.7.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+# [0.7.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
 
 **Note:** Version bump only for package @sd-jwt/jwt-status-list

--- a/packages/jwt-status-list/README.md
+++ b/packages/jwt-status-list/README.md
@@ -1,7 +1,7 @@
-![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![License](https://img.shields.io/github/license/openwallet-foundation/sd-jwt-js.svg)
 ![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Fhash)
-![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
-![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation/sd-jwt-js)
 
 # SD-JWT Implementation in JavaScript (TypeScript)
 

--- a/packages/jwt-status-list/package.json
+++ b/packages/jwt-status-list/package.json
@@ -28,12 +28,12 @@
     "node": ">=18"
   },
   "repository": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js"
   },
   "author": "Mirko Mollik <mirkomollik@gmail.com>",
-  "homepage": "https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki",
+  "homepage": "https://github.com/openwallet-foundation/sd-jwt-js/wiki",
   "bugs": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/node-crypto/CHANGELOG.md
+++ b/packages/node-crypto/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.15.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
+# [0.15.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.14.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
+# [0.14.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.13.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+# [0.13.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.12.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
+# [0.12.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.11.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
+# [0.11.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.10.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+# [0.10.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -51,7 +51,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
+## [0.9.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
+## [0.9.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.9.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
+# [0.9.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.8.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+# [0.8.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
+## [0.7.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+## [0.7.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -99,7 +99,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.7.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+# [0.7.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -107,7 +107,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.6.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
+## [0.6.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -115,7 +115,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.6.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+# [0.6.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
 
 **Note:** Version bump only for package @sd-jwt/crypto-nodejs
 
@@ -123,12 +123,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.5.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
+# [0.5.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
 
 
 
@@ -139,10 +139,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* add publish config ([#93](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
-* implement kbverify function ([#127](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/127)) ([e5609f2](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/e5609f26fab8c4991d3bd6c36066a95a30cfb972))
+* add publish config ([#93](https://github.com/openwallet-foundation/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
+* implement kbverify function ([#127](https://github.com/openwallet-foundation/sd-jwt-js/issues/127)) ([e5609f2](https://github.com/openwallet-foundation/sd-jwt-js/commit/e5609f26fab8c4991d3bd6c36066a95a30cfb972))
 
 
 ### Features
 
-* es crypto features to nodejs and browser ([#106](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/106)) ([3ba74e9](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/3ba74e936dbc39698d47c6c8c1da956430e937f8))
+* es crypto features to nodejs and browser ([#106](https://github.com/openwallet-foundation/sd-jwt-js/issues/106)) ([3ba74e9](https://github.com/openwallet-foundation/sd-jwt-js/commit/3ba74e936dbc39698d47c6c8c1da956430e937f8))

--- a/packages/node-crypto/README.md
+++ b/packages/node-crypto/README.md
@@ -1,7 +1,7 @@
-![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![License](https://img.shields.io/github/license/openwallet-foundation/sd-jwt-js.svg)
 ![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Fcrypto-nodejs)
-![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
-![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation/sd-jwt-js)
 
 # SD-JWT Implementation in JavaScript (TypeScript)
 
@@ -11,7 +11,7 @@
 
 Nodejs Crypto support for SD JWT
 
-Check the detail description in our github [repo](https://github.com/openwallet-foundation-labs/sd-jwt-js).
+Check the detail description in our github [repo](https://github.com/openwallet-foundation/sd-jwt-js).
 
 ### Installation
 
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/node-crypto/package.json
+++ b/packages/node-crypto/package.json
@@ -27,12 +27,12 @@
     "node": ">=18"
   },
   "repository": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js"
   },
   "author": "Lukas.J.Han <lukas.j.han@gmail.com>",
-  "homepage": "https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki",
+  "homepage": "https://github.com/openwallet-foundation/sd-jwt-js/wiki",
   "bugs": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/present/CHANGELOG.md
+++ b/packages/present/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.15.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
+# [0.15.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.14.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
+# [0.14.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.13.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+# [0.13.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.12.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
+# [0.12.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.11.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
+# [0.11.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.10.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+# [0.10.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -51,7 +51,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
+## [0.9.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
+## [0.9.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.9.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
+# [0.9.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.8.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+# [0.8.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
+## [0.7.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+## [0.7.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -99,7 +99,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.7.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+# [0.7.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -107,7 +107,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.6.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
+## [0.6.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
 
 **Note:** Version bump only for package @sd-jwt/present
 
@@ -115,28 +115,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.6.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+# [0.6.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
 
 
 ### Bug Fixes
 
-* add missing export ([#159](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/159)) ([f92b3e2](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f92b3e246371a83c51c5450b9bccb04753c58bf4))
+* add missing export ([#159](https://github.com/openwallet-foundation/sd-jwt-js/issues/159)) ([f92b3e2](https://github.com/openwallet-foundation/sd-jwt-js/commit/f92b3e246371a83c51c5450b9bccb04753c58bf4))
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([9baa93e](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/9baa93efb612ee2fe73c5872766cbc37e541c4dc))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([9baa93e](https://github.com/openwallet-foundation/sd-jwt-js/commit/9baa93efb612ee2fe73c5872766cbc37e541c4dc))
 
 
 
 
 
-# [0.5.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
+# [0.5.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
 
 
 
@@ -147,5 +147,5 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* add publish config ([#93](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
-* convert any usage into  or typed version ([#80](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/80)) ([de4df54](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/de4df54f2a0a77fdbf97e10abac555a98e70c6e0))
+* add publish config ([#93](https://github.com/openwallet-foundation/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
+* convert any usage into  or typed version ([#80](https://github.com/openwallet-foundation/sd-jwt-js/issues/80)) ([de4df54](https://github.com/openwallet-foundation/sd-jwt-js/commit/de4df54f2a0a77fdbf97e10abac555a98e70c6e0))

--- a/packages/present/README.md
+++ b/packages/present/README.md
@@ -1,7 +1,7 @@
-![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![License](https://img.shields.io/github/license/openwallet-foundation/sd-jwt-js.svg)
 ![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Fpresent)
-![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
-![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation/sd-jwt-js)
 
 # SD-JWT Implementation in JavaScript (TypeScript)
 
@@ -11,7 +11,7 @@
 
 Present SD JWT
 
-Check the detail description in our github [repo](https://github.com/openwallet-foundation-labs/sd-jwt-js).
+Check the detail description in our github [repo](https://github.com/openwallet-foundation/sd-jwt-js).
 
 ### Installation
 
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/present/package.json
+++ b/packages/present/package.json
@@ -28,12 +28,12 @@
     "node": ">=18"
   },
   "repository": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js"
   },
   "author": "Lukas.J.Han <lukas.j.han@gmail.com>",
-  "homepage": "https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki",
+  "homepage": "https://github.com/openwallet-foundation/sd-jwt-js/wiki",
   "bugs": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/sd-jwt-vc/CHANGELOG.md
+++ b/packages/sd-jwt-vc/CHANGELOG.md
@@ -3,89 +3,89 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.15.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.15.0...v0.15.1) (2025-08-28)
+## [0.15.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.15.0...v0.15.1) (2025-08-28)
 
 
 ### Bug Fixes
 
-* make iss claim optional in SD-JWT VC payload ([#310](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/310)) ([f6275e3](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f6275e35e66777709321328ba50fec53e5f48c7b))
+* make iss claim optional in SD-JWT VC payload ([#310](https://github.com/openwallet-foundation/sd-jwt-js/issues/310)) ([f6275e3](https://github.com/openwallet-foundation/sd-jwt-js/commit/f6275e35e66777709321328ba50fec53e5f48c7b))
 
 
 
 
 
-# [0.15.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
+# [0.15.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
 
 
 ### Features
 
-* Allows to pass a custom function for the status list JWT validation ([#306](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/306)) ([25e546e](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/25e546e1536178f8ee41b0e1b3836656fd6f48ab))
+* Allows to pass a custom function for the status list JWT validation ([#306](https://github.com/openwallet-foundation/sd-jwt-js/issues/306)) ([25e546e](https://github.com/openwallet-foundation/sd-jwt-js/commit/25e546e1536178f8ee41b0e1b3836656fd6f48ab))
 
 
 
 
 
-## [0.14.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.0...v0.14.1) (2025-08-02)
+## [0.14.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.0...v0.14.1) (2025-08-02)
 
 
 ### Bug Fixes
 
-* claim type ([#300](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/300)) ([3bab5ea](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/3bab5eae69b6ef872209ca00b5593f96b541bc03))
+* claim type ([#300](https://github.com/openwallet-foundation/sd-jwt-js/issues/300)) ([3bab5ea](https://github.com/openwallet-foundation/sd-jwt-js/commit/3bab5eae69b6ef872209ca00b5593f96b541bc03))
 
 
 
 
 
-# [0.14.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
-
-
-### Features
-
-* Add Verifier options ([#297](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/297)) ([2a6a367](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2a6a3674f94742f48feaf660056226b1a54145e7))
-
-
-
-
-
-# [0.13.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+# [0.14.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
 
 
 ### Features
 
-* fetch VCT Metadata from SD JWT header ([#288](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/288)) ([#294](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/294)) ([f89ba44](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f89ba445aeb57ce342ec76b58a0eb6d0c090a4e9))
+* Add Verifier options ([#297](https://github.com/openwallet-foundation/sd-jwt-js/issues/297)) ([2a6a367](https://github.com/openwallet-foundation/sd-jwt-js/commit/2a6a3674f94742f48feaf660056226b1a54145e7))
 
 
 
 
 
-# [0.12.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
+# [0.13.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+
+
+### Features
+
+* fetch VCT Metadata from SD JWT header ([#288](https://github.com/openwallet-foundation/sd-jwt-js/issues/288)) ([#294](https://github.com/openwallet-foundation/sd-jwt-js/issues/294)) ([f89ba44](https://github.com/openwallet-foundation/sd-jwt-js/commit/f89ba445aeb57ce342ec76b58a0eb6d0c090a4e9))
+
+
+
+
+
+# [0.12.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
 
 
 ### Bug Fixes
 
-* expose types ([#290](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/290)) ([1b656ac](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/1b656ac21796b715096feae439de6b48442244a9))
+* expose types ([#290](https://github.com/openwallet-foundation/sd-jwt-js/issues/290)) ([1b656ac](https://github.com/openwallet-foundation/sd-jwt-js/commit/1b656ac21796b715096feae439de6b48442244a9))
 
 
 ### Features
 
-* add missing types ([#286](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/286)) ([506b876](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/506b8769ac8e0082ad30544338eace2d0df34294))
+* add missing types ([#286](https://github.com/openwallet-foundation/sd-jwt-js/issues/286)) ([506b876](https://github.com/openwallet-foundation/sd-jwt-js/commit/506b8769ac8e0082ad30544338eace2d0df34294))
 
 
 
 
 
-# [0.11.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
+# [0.11.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
 
 
 ### Features
 
-* SD JWT Instances VCT Metadata get separated from verify ([#285](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/285)) ([bc91fd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/bc91fd71f7d721298ad5c08d4379bc870903f65f))
+* SD JWT Instances VCT Metadata get separated from verify ([#285](https://github.com/openwallet-foundation/sd-jwt-js/issues/285)) ([bc91fd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/bc91fd71f7d721298ad5c08d4379bc870903f65f))
 
 
 
 
 
-# [0.10.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+# [0.10.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
 
 **Note:** Version bump only for package @sd-jwt/sd-jwt-vc
 
@@ -93,7 +93,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
+## [0.9.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
 
 **Note:** Version bump only for package @sd-jwt/sd-jwt-vc
 
@@ -101,7 +101,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
+## [0.9.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
 
 **Note:** Version bump only for package @sd-jwt/sd-jwt-vc
 
@@ -109,42 +109,34 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.9.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
+# [0.9.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
 
 
 ### Features
 
-* align type metadata fetching with sd-jwt-vc draft 08 ([#260](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/260)) ([2358c75](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2358c759887ee29b4c35a3ee0e93ebd8e8c26545))
+* align type metadata fetching with sd-jwt-vc draft 08 ([#260](https://github.com/openwallet-foundation/sd-jwt-js/issues/260)) ([2358c75](https://github.com/openwallet-foundation/sd-jwt-js/commit/2358c759887ee29b4c35a3ee0e93ebd8e8c26545))
 
 
 
 
 
-# [0.8.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+# [0.8.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
 
 
 ### Bug Fixes
 
-* check if the header includes the string ([#244](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/244)) ([8a48bb5](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/8a48bb57fcf9bbad349f349b0aa1ffd997c86bb2))
+* check if the header includes the string ([#244](https://github.com/openwallet-foundation/sd-jwt-js/issues/244)) ([8a48bb5](https://github.com/openwallet-foundation/sd-jwt-js/commit/8a48bb57fcf9bbad349f349b0aa1ffd997c86bb2))
 
 
 ### Features
 
-* align media type with sd-jwt-vc draft 06 ([#256](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/256)) ([1aa3aea](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/1aa3aea86213e75328975e34d9bf71410fc7a12a))
+* align media type with sd-jwt-vc draft 06 ([#256](https://github.com/openwallet-foundation/sd-jwt-js/issues/256)) ([1aa3aea](https://github.com/openwallet-foundation/sd-jwt-js/commit/1aa3aea86213e75328975e34d9bf71410fc7a12a))
 
 
 
 
 
-## [0.7.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
-
-**Note:** Version bump only for package @sd-jwt/sd-jwt-vc
-
-
-
-
-
-## [0.7.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+## [0.7.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
 
 **Note:** Version bump only for package @sd-jwt/sd-jwt-vc
 
@@ -152,7 +144,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.7.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+## [0.7.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
 
 **Note:** Version bump only for package @sd-jwt/sd-jwt-vc
 
@@ -160,18 +152,26 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.6.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
+# [0.7.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+
+**Note:** Version bump only for package @sd-jwt/sd-jwt-vc
+
+
+
+
+
+## [0.6.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
 
 
 ### Bug Fixes
 
-* **sd-jwt-vc:** improve alignment with draft-03 ([#175](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/175)) ([bcd7d6e](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/bcd7d6e40fff938d06425d69297274400ab9e8a6))
+* **sd-jwt-vc:** improve alignment with draft-03 ([#175](https://github.com/openwallet-foundation/sd-jwt-js/issues/175)) ([bcd7d6e](https://github.com/openwallet-foundation/sd-jwt-js/commit/bcd7d6e40fff938d06425d69297274400ab9e8a6))
 
 
 
 
 
-# [0.6.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+# [0.6.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
 
 **Note:** Version bump only for package @sd-jwt/sd-jwt-vc
 
@@ -179,12 +179,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.5.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
+# [0.5.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
 
 
 
@@ -195,10 +195,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* change SDJwtPayload to SdJwtPayload ([9f06ef7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/9f06ef7bd31a1dff4e9bf988e425200a5e1aa82d))
-* make sdjwt instance non abstract ([#122](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/122)) ([e85aae8](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/e85aae89910f5d9468e29ef14ef3b3d3215b86fd))
+* change SDJwtPayload to SdJwtPayload ([9f06ef7](https://github.com/openwallet-foundation/sd-jwt-js/commit/9f06ef7bd31a1dff4e9bf988e425200a5e1aa82d))
+* make sdjwt instance non abstract ([#122](https://github.com/openwallet-foundation/sd-jwt-js/issues/122)) ([e85aae8](https://github.com/openwallet-foundation/sd-jwt-js/commit/e85aae89910f5d9468e29ef14ef3b3d3215b86fd))
 
 
 ### Features
 
-* add new package for sd-jwt-vc ([ed99188](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/ed99188f13184d58db64b4211e39fb67f3f78cb5))
+* add new package for sd-jwt-vc ([ed99188](https://github.com/openwallet-foundation/sd-jwt-js/commit/ed99188f13184d58db64b4211e39fb67f3f78cb5))

--- a/packages/sd-jwt-vc/README.md
+++ b/packages/sd-jwt-vc/README.md
@@ -1,7 +1,7 @@
-![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![License](https://img.shields.io/github/license/openwallet-foundation/sd-jwt-js.svg)
 ![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Fcore)
-![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
-![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation/sd-jwt-js)
 
 # SD-JWT Implementation in JavaScript (TypeScript)
 
@@ -11,7 +11,7 @@
 
 SD-JWT-VC format based on the core functions
 
-Check the detail description in our github [repo](https://github.com/openwallet-foundation-labs/sd-jwt-js).
+Check the detail description in our github [repo](https://github.com/openwallet-foundation/sd-jwt-js).
 
 ### Installation
 
@@ -81,7 +81,7 @@ const presentation = await sdjwt.present(credential, presentationFrame);
 const verified = await sdjwt.verify(presentation);
 ```
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/examples)
 
 ### Revocation
 

--- a/packages/sd-jwt-vc/package.json
+++ b/packages/sd-jwt-vc/package.json
@@ -29,12 +29,12 @@
     "node": ">=18"
   },
   "repository": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js"
   },
   "author": "Lukas.J.Han <lukas.j.han@gmail.com>",
-  "homepage": "https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki",
+  "homepage": "https://github.com/openwallet-foundation/sd-jwt-js/wiki",
   "bugs": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.15.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
+# [0.15.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.14.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
+# [0.14.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.13.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+# [0.13.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.12.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
+# [0.12.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.11.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
+# [0.11.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.10.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+# [0.10.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -51,26 +51,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
+## [0.9.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
 
 
 ### Bug Fixes
 
-* Frame fails when a type with an optional or nullable field is used ([#272](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/272)) ([ed907e3](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/ed907e33c79f140268a03098af1e8c5cc1003ce9))
+* Frame fails when a type with an optional or nullable field is used ([#272](https://github.com/openwallet-foundation/sd-jwt-js/issues/272)) ([ed907e3](https://github.com/openwallet-foundation/sd-jwt-js/commit/ed907e33c79f140268a03098af1e8c5cc1003ce9))
 
 
 
 
 
-## [0.9.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
-
-**Note:** Version bump only for package @sd-jwt/types
-
-
-
-
-
-# [0.9.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
+## [0.9.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -78,7 +70,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.8.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+# [0.9.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -86,7 +78,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
+# [0.8.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -94,7 +86,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+## [0.7.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -102,7 +94,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.7.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+## [0.7.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -110,7 +102,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.6.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
+# [0.7.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -118,7 +110,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.6.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+## [0.6.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
 
 **Note:** Version bump only for package @sd-jwt/types
 
@@ -126,12 +118,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.5.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
+# [0.6.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+
+**Note:** Version bump only for package @sd-jwt/types
+
+
+
+
+
+# [0.5.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
 
 
 
@@ -142,15 +142,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* add publish config ([#93](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
-* format file ([28202b2](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/28202b20daf80225cea0f5415a14b623276c6188))
-* implement kbverify function ([#127](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/127)) ([e5609f2](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/e5609f26fab8c4991d3bd6c36066a95a30cfb972))
-* update type of credential ([63d5ebb](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/63d5ebb4e3e5dd34ae8f82b2ef890a9b2647654f))
+* add publish config ([#93](https://github.com/openwallet-foundation/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
+* format file ([28202b2](https://github.com/openwallet-foundation/sd-jwt-js/commit/28202b20daf80225cea0f5415a14b623276c6188))
+* implement kbverify function ([#127](https://github.com/openwallet-foundation/sd-jwt-js/issues/127)) ([e5609f2](https://github.com/openwallet-foundation/sd-jwt-js/commit/e5609f26fab8c4991d3bd6c36066a95a30cfb972))
+* update type of credential ([63d5ebb](https://github.com/openwallet-foundation/sd-jwt-js/commit/63d5ebb4e3e5dd34ae8f82b2ef890a9b2647654f))
 
 
 ### Features
 
-* add jwk type ([#130](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/130)) ([8ce255a](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/8ce255a64b0940e92e647aa544bf5990b48279b7))
-* add new package for sd-jwt-vc ([ed99188](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/ed99188f13184d58db64b4211e39fb67f3f78cb5))
-* calcuate sd_hash in kb JWT ([#117](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/117)) ([3415550](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/3415550fbcd99f97babff442a4928cc827c5c9cc))
-* restore rsa type in JWK ([#137](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/137)) ([fe0d8f6](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/fe0d8f6a3249dfea27b08f82165555de389efe1d))
+* add jwk type ([#130](https://github.com/openwallet-foundation/sd-jwt-js/issues/130)) ([8ce255a](https://github.com/openwallet-foundation/sd-jwt-js/commit/8ce255a64b0940e92e647aa544bf5990b48279b7))
+* add new package for sd-jwt-vc ([ed99188](https://github.com/openwallet-foundation/sd-jwt-js/commit/ed99188f13184d58db64b4211e39fb67f3f78cb5))
+* calcuate sd_hash in kb JWT ([#117](https://github.com/openwallet-foundation/sd-jwt-js/issues/117)) ([3415550](https://github.com/openwallet-foundation/sd-jwt-js/commit/3415550fbcd99f97babff442a4928cc827c5c9cc))
+* restore rsa type in JWK ([#137](https://github.com/openwallet-foundation/sd-jwt-js/issues/137)) ([fe0d8f6](https://github.com/openwallet-foundation/sd-jwt-js/commit/fe0d8f6a3249dfea27b08f82165555de389efe1d))

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,7 +1,7 @@
-![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![License](https://img.shields.io/github/license/openwallet-foundation/sd-jwt-js.svg)
 ![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Ftypes)
-![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
-![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation/sd-jwt-js)
 
 # SD-JWT Implementation in JavaScript (TypeScript)
 
@@ -11,7 +11,7 @@
 
 Types for SD JWT
 
-Check the detail description in our github [repo](https://github.com/openwallet-foundation-labs/sd-jwt-js).
+Check the detail description in our github [repo](https://github.com/openwallet-foundation/sd-jwt-js).
 
 ### Installation
 
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -28,12 +28,12 @@
     "node": ">=18"
   },
   "repository": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js"
   },
   "author": "Lukas.J.Han <lukas.j.han@gmail.com>",
-  "homepage": "https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki",
+  "homepage": "https://github.com/openwallet-foundation/sd-jwt-js/wiki",
   "bugs": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.15.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
+# [0.15.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.14.1...v0.15.0) (2025-08-20)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.14.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
+# [0.14.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.13.0...v0.14.0) (2025-06-30)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.13.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
+# [0.13.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.12.0...v0.13.0) (2025-06-25)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.12.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
+# [0.12.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.11.0...v0.12.0) (2025-06-21)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.11.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
+# [0.11.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.10.0...v0.11.0) (2025-06-17)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.10.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
+# [0.10.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.2...v0.10.0) (2025-03-24)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -51,7 +51,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
+## [0.9.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.1...v0.9.2) (2025-01-29)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
+## [0.9.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.9.0...v0.9.1) (2024-12-13)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.9.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
+# [0.9.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.8.0...v0.9.0) (2024-12-10)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.8.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
+# [0.8.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.2...v0.8.0) (2024-11-26)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.2](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
+## [0.7.2](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.1...v0.7.2) (2024-07-19)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.7.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
+## [0.7.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.7.0...v0.7.1) (2024-05-21)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -99,7 +99,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.7.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
+# [0.7.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.1...v0.7.0) (2024-05-13)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -107,18 +107,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.6.1](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
+## [0.6.1](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.6.0...v0.6.1) (2024-03-18)
 
 
 ### Bug Fixes
 
-* base64url convention ([#179](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/179)) ([f8db275](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/f8db275690dab88000a039838680a3478b3b61ec))
+* base64url convention ([#179](https://github.com/openwallet-foundation/sd-jwt-js/issues/179)) ([f8db275](https://github.com/openwallet-foundation/sd-jwt-js/commit/f8db275690dab88000a039838680a3478b3b61ec))
 
 
 
 
 
-# [0.6.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
+# [0.6.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.5.0...v0.6.0) (2024-03-12)
 
 **Note:** Version bump only for package @sd-jwt/utils
 
@@ -126,12 +126,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.5.0](https://github.com/openwallet-foundation-labs/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
+# [0.5.0](https://github.com/openwallet-foundation/sd-jwt-js/compare/v0.4.0...v0.5.0) (2024-03-11)
 
 
 ### Features
 
-* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
+* make _digest value public in disclosure ([#151](https://github.com/openwallet-foundation/sd-jwt-js/issues/151)) ([7a3fbd7](https://github.com/openwallet-foundation/sd-jwt-js/commit/7a3fbd7db19b6501978340c972b171743d287285))
 
 
 
@@ -142,5 +142,5 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* add publish config ([#93](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
-* convert any usage into  or typed version ([#80](https://github.com/openwallet-foundation-labs/sd-jwt-js/issues/80)) ([de4df54](https://github.com/openwallet-foundation-labs/sd-jwt-js/commit/de4df54f2a0a77fdbf97e10abac555a98e70c6e0))
+* add publish config ([#93](https://github.com/openwallet-foundation/sd-jwt-js/issues/93)) ([2e4c5c1](https://github.com/openwallet-foundation/sd-jwt-js/commit/2e4c5c176dc88e58e49d06783b7658d8ad872313))
+* convert any usage into  or typed version ([#80](https://github.com/openwallet-foundation/sd-jwt-js/issues/80)) ([de4df54](https://github.com/openwallet-foundation/sd-jwt-js/commit/de4df54f2a0a77fdbf97e10abac555a98e70c6e0))

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,7 +1,7 @@
-![License](https://img.shields.io/github/license/openwallet-foundation-labs/sd-jwt-js.svg)
+![License](https://img.shields.io/github/license/openwallet-foundation/sd-jwt-js.svg)
 ![NPM](https://img.shields.io/npm/v/%40sd-jwt%2Futils)
-![Release](https://img.shields.io/github/v/release/openwallet-foundation-labs/sd-jwt-js)
-![Stars](https://img.shields.io/github/stars/openwallet-foundation-labs/sd-jwt-js)
+![Release](https://img.shields.io/github/v/release/openwallet-foundation/sd-jwt-js)
+![Stars](https://img.shields.io/github/stars/openwallet-foundation/sd-jwt-js)
 
 # SD-JWT Implementation in JavaScript (TypeScript)
 
@@ -11,7 +11,7 @@
 
 Utility functions for SD JWT
 
-Check the detail description in our github [repo](https://github.com/openwallet-foundation-labs/sd-jwt-js).
+Check the detail description in our github [repo](https://github.com/openwallet-foundation/sd-jwt-js).
 
 ### Installation
 
@@ -32,7 +32,7 @@ Ensure you have Node.js installed as a prerequisite.
 
 ### Usage
 
-Check out more details in our [documentation](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation-labs/sd-jwt-js/tree/main/examples)
+Check out more details in our [documentation](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/examples)
 
 ### Dependencies
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -28,12 +28,12 @@
     "node": ">=18"
   },
   "repository": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js"
   },
   "author": "Lukas.J.Han <lukas.j.han@gmail.com>",
-  "homepage": "https://github.com/openwallet-foundation-labs/sd-jwt-js/wiki",
+  "homepage": "https://github.com/openwallet-foundation/sd-jwt-js/wiki",
   "bugs": {
-    "url": "https://github.com/openwallet-foundation-labs/sd-jwt-js/issues"
+    "url": "https://github.com/openwallet-foundation/sd-jwt-js/issues"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
Github will redirect, but this will still collide with the trusted publishing

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>