### PR TITLE
fix: release ci, node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['18.x', '20.x']
+        node-version: ['20.x', '22.x', '24.x']
     steps:
       - uses: pnpm/action-setup@v3
         with:


### PR DESCRIPTION
Adjust node version also in release github action, removing node version 18, adding 24

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>