### PR TITLE
feat: allow undefined type metadata to be returned by resolver

### DIFF
--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -134,7 +134,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
    * @param encodedSDJwt
    * @returns
    */
-  async getVct(encodedSDJwt: string): Promise<TypeMetadataFormat> {
+  async getVct(encodedSDJwt: string): Promise<TypeMetadataFormat | undefined> {
     // Call the parent class's verify method
     const { payload, header } = await SDJwt.extractJwt<
       Record<string, unknown>,
@@ -168,7 +168,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
       // validate the integrity of the response according to https://www.w3.org/TR/SRI/
       const arrayBuffer = await response.arrayBuffer();
       const alg = integrity.split('-')[0];
-      //TODO: error handling when a hasher is passed that is not supporting the required algorithm acording to the spec
+      //TODO: error handling when a hasher is passed that is not supporting the required algorithm according to the spec
       const hashBuffer = await (this.userConfig.hasher as Hasher)(
         arrayBuffer,
         alg,
@@ -221,7 +221,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
   ): Promise<TypeMetadataFormat | undefined> {
     const typeMetadataFormat = await this.fetchVct(result);
 
-    if (typeMetadataFormat.extends) {
+    if (typeMetadataFormat?.extends) {
       // implement based on https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-08.html#name-extending-type-metadata
       //TODO: needs to be implemented. Unclear at this point which values will overwrite the values from the extended type metadata format
     }
@@ -236,7 +236,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
    */
   private async fetchVct(
     result: VerificationResult,
-  ): Promise<TypeMetadataFormat> {
+  ): Promise<TypeMetadataFormat | undefined> {
     if (!result.payload.vct) {
       throw new SDJWTException('vct claim is required');
     }

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-vct.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-vct.ts
@@ -3,4 +3,4 @@ import type { TypeMetadataFormat } from './sd-jwt-vc-type-metadata-format';
 export type VcTFetcher = (
   uri: string,
   integrity?: string,
-) => Promise<TypeMetadataFormat>;
+) => Promise<TypeMetadataFormat | undefined>;


### PR DESCRIPTION
This is a small PR that addresses the issue in https://github.com/openwallet-foundation/sd-jwt-js/issues/258.

I know that PR was closed, I just wanted to show what we'd need to be able to leverage the VCT resolving logic from this library (currently we bypass it and fetch it ourselves, but we lose the other parts, e.g. integrity verification, as well with that).

We have several cases where the resolver may return undefined when fetching a VCT:
- We have issued credentials with a VCT that was a HTTPS url without type metadata. Again I don't see requirements in the spec that the HTTPS url MUST host type metadata.
- This will also allow it to be used for non-https URLs. You just always try to fetch it, but the resolver defines if it konwns a type metadata object for the vct (e.g. `urn:eudi:pid:1` it would know that there's a different place to resolve it), for other type it may return undefined because the vct is unknown.


This is a breaking though, since the return type of `getVct` changes, although functionality there's no change, since the default vct fetcher still requires a succesfull response.

