### PR TITLE
feat: generic integrity types, injection (calculator) and parsing

### DIFF
--- a/packages/sd-jwt-vc/src/sd-jwt-vc-payload.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-payload.ts
@@ -1,4 +1,5 @@
 import type { SdJwtPayload } from '@sd-jwt/core';
+import type { IntegrityMetadata } from '@sd-jwt/utils';
 import type { SDJWTVCStatusReference } from './sd-jwt-vc-status-reference';
 
 export interface SdJwtVcPayload extends SdJwtPayload {
@@ -13,7 +14,7 @@ export interface SdJwtVcPayload extends SdJwtPayload {
   // REQUIRED. The type of the Verifiable Credential, e.g., https://credentials.example.com/identity_credential, as defined in Section 3.2.2.1.1.
   vct: string;
   // OPTIONAL. If passed, the loaded type metadata format has to be validated according to https://www.w3.org/TR/SRI/
-  'vct#integrity'?: string;
+  'vct#integrity'?: IntegrityMetadata;
   // OPTIONAL. The information on how to read the status of the Verifiable Credential. See [https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-02.html] for more information.
   status?: SDJWTVCStatusReference;
   // OPTIONAL. The identifier of the Subject of the Verifiable Credential. The Issuer MAY use it to provide the Subject identifier known by the Issuer. There is no requirement for a binding to exist between sub and cnf claims.

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-type-metadata-format.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-type-metadata-format.ts
@@ -1,3 +1,5 @@
+import type { IntegrityMetadata } from '@sd-jwt/utils';
+
 /**
  * Logo metadata used in rendering a credential.
  */
@@ -5,7 +7,7 @@ export type Logo = {
   /** REQUIRED. A URI pointing to the logo image. */
   uri: string;
   /** OPTIONAL. An "integrity metadata" string as described in Section 7. */
-  'uri#integrity'?: string;
+  'uri#integrity'?: IntegrityMetadata;
   /** OPTIONAL. A string containing alternative text for the logo image. */
   alt_text?: string;
 };
@@ -50,7 +52,7 @@ export type SvgTemplateRendering = {
   /** REQUIRED. A URI pointing to the SVG template. */
   uri: string;
   /** OPTIONAL. An "integrity metadata" string as described in Section 7. */
-  'uri#integrity'?: string;
+  'uri#integrity'?: IntegrityMetadata;
   /** REQUIRED if more than one SVG template is present. */
   properties?: SvgTemplateProperties;
 };
@@ -136,7 +138,7 @@ export type TypeMetadataFormat = {
   /** OPTIONAL. URI of another type that this one extends. */
   extends?: string;
   /** OPTIONAL. Integrity metadata for the 'extends' field. */
-  'extends#integrity'?: string;
+  'extends#integrity'?: IntegrityMetadata;
   /** OPTIONAL. Array of localized display metadata for the type. */
   display?: Display[];
   /** OPTIONAL. Array of claim metadata. */

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,6 @@
 export * from './base64url';
 export * from './disclosure';
 export * from './error';
+export * from './integrity';
+export * from './integrity_calculator';
+export * from './integrity_parser';

--- a/packages/utils/src/integrity.ts
+++ b/packages/utils/src/integrity.ts
@@ -1,0 +1,206 @@
+type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+export type IntegrityHashAlg = 'sha256' | 'sha384' | 'sha512' | (string & {});
+type WSP = ' ' | '\t' | '\n' | '\r';
+
+/**
+ * Represents a single SRI hash expression.
+ *
+ * `algorithm "-" hash-value [ "?" option-expression ]`
+ *
+ * @example "sha256-AbCd..."
+ * @example "sha256-AbCd...?foo=bar"
+ */
+export type IntegrityDigest =
+  | `${IntegrityHashAlg}-${string}`
+  | `${IntegrityHashAlg}-${string}?${string}`;
+
+/**
+ * W3C SRI (Subresource Integrity) compatible metadata string.
+ *
+ * Allows for multiple whitespace-separated digest expressions.
+ *
+ * @see https://www.w3.org/TR/sri-2/#integrity-metadata-syntax
+ */
+export type IntegrityMetadata =
+  | IntegrityDigest
+  | `${IntegrityDigest}${WSP}${string}`;
+
+type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+type Lower0 = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j';
+type Lower1 = 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't';
+type Lower = 'u' | 'v' | 'w' | 'x' | 'y' | 'z' | Lower0 | Lower1;
+type Upper = Uppercase<Lower>;
+type ValidStart = Lower | Upper | '_' | '$';
+type ValidChar = ValidStart | Digit;
+
+/**
+ * Recursively checks if 'S' contains ONLY valid identifier characters.
+ * Returns true if safe, false if it contains special chars (-, /, :, space, etc).
+ */
+type IsClean<S extends string> = S extends ''
+  ? true
+  : S extends `${infer Char}${infer Rest}`
+    ? Char extends ValidChar
+      ? IsClean<Rest>
+      : false // Found invalid char
+    : false;
+
+/**
+ * Determines if 'S' is a valid JSONPath identifier safe for dot notation.
+ * Rule: Must start with [a-zA-Z_$] and contain only [a-zA-Z0-9_$].
+ */
+type IsValidIdentifier<S extends string> = S extends `${infer First}${string}`
+  ? First extends ValidStart
+    ? IsClean<S>
+    : false
+  : false;
+
+/**
+ * Formats a key segment according to JSONPath/TS12 rules.
+ * - Simple ID -> .key
+ * - Complex ID -> ['key']
+ */
+type FormatSegment<Key extends string | number> = Key extends number
+  ? `[${Key}]` // Literal number -> [0]
+  : Key extends `${number}`
+    ? `[${Key}]` // Stringified number -> [0]
+    : IsValidIdentifier<Key & string> extends true
+      ? `.${Key}` // Simple ID -> .key
+      : `['${Key}']`; // Complex ID -> ['key']
+
+/**
+ * Helper: Removes a leading dot from the remaining path if present.
+ * Used when transitioning from Bracket -> Dot (e.g. ['a'].b -> b)
+ */
+type StripDot<S extends string> = S extends `.${infer R}` ? R : S;
+export type { StripDot as _StripDot };
+
+/**
+ * Core Parser Logic.
+ * Handles:
+ * 1. Bracket Start: ['key']... or ["key"]... or [*]...
+ * 2. Dot Split: key.rest
+ * 3. Bracket Split: key['rest']
+ */
+type ParsePath<T, P extends string, Out extends string = ''> = P extends `['${
+  infer K // Bracket Quoted: ['key'] or ["key"]
+}']${infer Rest}`
+  ? HandleNext<T, K, StripDot<Rest>, Out>
+  : P extends `["${infer K}"]${infer Rest}`
+    ? HandleNext<T, K, StripDot<Rest>, Out>
+    : // Bracket Wildcard [*] -> Treat as *
+      P extends `[*]${infer Rest}`
+      ? HandleNext<T, '*', StripDot<Rest>, Out>
+      : // Numeric Index [0] -> Treat as key "0"
+        P extends `[${infer K extends number}]${infer Rest}`
+        ? HandleNext<T, `${K}`, StripDot<Rest>, Out>
+        : // Dot vs Bracket Logic
+          P extends `${infer HeadBracket}[${infer RestBracket}`
+          ? P extends `${infer HeadDot}.${infer RestDot}`
+            ? HeadBracket extends `${string}.${string}`
+              ? HandleNext<T, HeadDot, RestDot, Out> // Dot is first
+              : HandleNext<T, HeadBracket, `[${RestBracket}`, Out> // Bracket is first
+            : HandleNext<T, HeadBracket, `[${RestBracket}`, Out> // Only Bracket
+          : P extends `${infer HeadDot}.${infer RestDot}`
+            ? HandleNext<T, HeadDot, RestDot, Out> // Only Dot
+            : HandleNext<T, P, '', Out>; // Terminal
+
+/**
+ * Recursive Handler:
+ * 1. Appends the formatted key to 'Out'.
+ * 2. Recurses into T[Key].
+ */
+type HandleNext<
+  T,
+  K extends string,
+  Rest extends string,
+  Out extends string,
+> = K extends '*'
+  ? // array: Iterate generic 'number' index
+    T extends readonly unknown[]
+    ? Rest extends ''
+      ? `${Out}[${number}]#integrity`
+      : ParsePath<T[number], Rest, `${Out}[${number}]`>
+    : // object: Iterate real keys
+      T extends object
+      ? keyof T extends infer Key
+        ? Key extends keyof T & (string | number)
+          ? Rest extends ''
+            ? `${Out}${FormatSegment<Key>}#integrity`
+            : ParsePath<T[Key], Rest, `${Out}${FormatSegment<Key>}`>
+          : never
+        : never
+      : never
+  : // 3. leaf key
+    K extends keyof T
+    ? Rest extends ''
+      ? `${Out}${FormatSegment<K>}#integrity`
+      : ParsePath<T[K], Rest, `${Out}${FormatSegment<K>}`>
+    : never;
+
+/**
+ * Extracts the specific JSON keys (ending in `#integrity`) that will be added
+ * to the type `T` given the input `Paths`.
+ *
+ * This is useful for introspection or creating derived types that need to know
+ * exactly which integrity fields are expected.
+ *
+ * @example
+ * type Keys = IntegrityKeys<Cred, 'vct' | 'claims.*'>;
+ * // Result: "vct#integrity" | "claims.name#integrity" | "claims.age#integrity"
+ */
+export type IntegrityKeys<T, Paths extends string> = StripDot<
+  ParsePath<T, Paths>
+>;
+
+/**
+ * Intersects a base type `T` with integrity protection fields for specific JSON paths.
+ *
+ * This type utility takes a base object and a union of string paths. It maps over the
+ * `Paths`, transforming them into JSON paths with the `#integrity` suffix,
+ * and sets their value type to `IntegrityDigest`.
+ *
+ * @template T - The base object type (e.g., the credential payload).
+ * @template Paths - A union of string literal paths indicating which fields require integrity protection.
+ *
+ * @example
+ * ```ts
+ * type PaymentPayload = {
+ *   iss: string;
+ *   sub: string;
+ *   vct: string;
+ *   transaction_data_types: Record<string, {
+ *     schema_uri: string;
+ *     ui_labels_uri: string;
+ *   }>;
+ * };
+ *
+ * type SecuredPayment = Integrity<
+ *   PaymentPayload,
+ *   'vct' | 'transaction_data_types.*.schema_uri' | 'transaction_data_types.*.ui_labels_uri'
+ * >;
+ *
+ * const cred: SecuredPayment = {
+ *   iss: 'https://issuer.superbank3.com',
+ *   sub: '37774a3f-ab14-43c3-96bc-bb1066a30a1d',
+ *
+ *   vct: 'https://psd2.standard.org/payment_service_user',
+ *
+ *   transaction_data_types: {
+ *     'https://standardsbody.org/eudiw-trx/payment': {
+ *       schema_uri: 'https://schemas.org/payment-v1',
+ *       ui_labels_uri: 'https://ui.org/payment-labels',
+ *     }
+ *   }
+ *   'vct#integrity': 'sha256-9cLlJNXN-TsMk-..5ca_xGgX3c1VLmXfh-WRL5',
+ *   'transaction_data_types['https://standardsbody.org/eudiw-trx/payment'].schema_uri#integrity': 'sha256-e3b0c44298fc49afbf4...a495991852b855',
+ *   'transaction_data_types['https://standardsbody.org/eudiw-trx/payment'].ui_labels_uri#integrity': 'sha256-335f3750519114d2a93...5e6ed24c30c0317'
+ * };
+ * ```
+ */
+export type Integrity<T, Paths extends string> = Prettify<
+  T & {
+    [K in Paths as StripDot<ParsePath<T, K>>]?: IntegrityMetadata;
+  }
+>;

--- a/packages/utils/src/integrity_calculator.ts
+++ b/packages/utils/src/integrity_calculator.ts
@@ -1,0 +1,145 @@
+import type {
+  _StripDot,
+  Integrity,
+  IntegrityDigest,
+  IntegrityKeys,
+  IntegrityMetadata,
+} from './integrity';
+
+type GetValue<T, K> = K extends keyof T ? T[K] : never;
+type PathValue<T, P extends string> = P extends `['${infer K}']${infer Rest}`
+  ? PathValue<GetValue<T, K>, _StripDot<Rest>>
+  : P extends `["${infer K}"]${infer Rest}`
+    ? PathValue<GetValue<T, K>, _StripDot<Rest>>
+    : // Bracket Wildcard [*] -> Return Element Type
+      P extends `[*]${infer Rest}`
+      ? T extends readonly unknown[]
+        ? PathValue<T[number], _StripDot<Rest>>
+        : PathValue<GetValue<T, keyof T>, _StripDot<Rest>>
+      : // Standard Wildcard * -> Return Element Type
+        P extends `*${infer Rest}`
+        ? T extends readonly unknown[]
+          ? PathValue<T[number], _StripDot<Rest>>
+          : PathValue<GetValue<T, keyof T>, _StripDot<Rest>>
+        : // Array Index [0] -> Return Element Type
+          P extends `[${infer K extends number}]${infer Rest}`
+          ? T extends readonly unknown[]
+            ? PathValue<T[K], _StripDot<Rest>>
+            : never
+          : // Dot vs Bracket Split
+            P extends `${infer HeadBracket}[${infer RestBracket}`
+            ? P extends `${infer HeadDot}.${infer RestDot}`
+              ? HeadBracket extends `${string}.${string}`
+                ? PathValue<GetValue<T, HeadDot>, RestDot>
+                : PathValue<GetValue<T, HeadBracket>, `[${RestBracket}`>
+              : PathValue<GetValue<T, HeadBracket>, `[${RestBracket}`>
+            : P extends `${infer HeadDot}.${infer RestDot}`
+              ? PathValue<GetValue<T, HeadDot>, RestDot>
+              : P extends keyof T
+                ? T[P]
+                : never;
+
+/**
+ * A strongly typed hasher.
+ * Key is the union of possible keys, and value the union of possible field values to has.
+ * The integrity is expected to be the content of URIs, so it is necessary to either do a web lookup or do a local lookup of the data if self hosted.
+ */
+export type DigestFn<T, K extends string> = (
+  key: IntegrityKeys<T, K>,
+  value: PathValue<T, K>,
+) => Promise<IntegrityDigest> | IntegrityDigest;
+
+/**
+ * Splits a path string into segments.
+ */
+export function _splitPath(path: string): string[] {
+  // Regex matches:
+  // 1. Quoted Brackets: ['...'] or ["..."]
+  // 2. Numeric Index:   [123]
+  // 3. Bracket Wild:    [*]
+  // 4. Dot Wild:        *
+  // 5. Identifiers:     name
+  const regex = /(\['[^']+']|\["[^"]+"]|\[\d+]|\[\*]|\*|[a-zA-Z0-9_$]+)/g;
+  return (path.match(regex) || []).map((it) => {
+    if (it === '*' || it === '[*]') return '*';
+    // clean keys
+    return it.startsWith('[') ? it.replace(/^\[['"]?|['"]?]$/g, '') : it;
+  });
+}
+
+function resolvePaths(
+  currentVal: unknown,
+  segments: string[],
+  currentPath: string,
+): Array<{ path: string; value: unknown }> {
+  if (segments.length === 0) {
+    return [{ path: currentPath, value: currentVal }];
+  }
+
+  const toSegment = (key: string) =>
+    /^[0-9]*$/.test(key)
+      ? `[${key}]`
+      : /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key)
+        ? `.${key}`
+        : `['${key}']`;
+
+  const toNextPath = (key: string) =>
+    currentPath
+      ? `${currentPath}${toSegment(key)}`
+      : toSegment(key).replace(/^\./, '');
+
+  const [head, ...tail] = segments;
+  const results: Array<{ path: string; value: unknown }> = [];
+
+  // Handle Wildcard (* OR [*])
+  let toResolve: { key: string; nextPath: string }[] = [];
+  if (head === '*') {
+    if (typeof currentVal === 'object' && currentVal !== null) {
+      toResolve = Object.keys(currentVal).map((key) => ({
+        key: key,
+        nextPath: toNextPath(key),
+      }));
+    }
+  } else {
+    toResolve = [{ key: head, nextPath: toNextPath(head) }];
+  }
+
+  for (const { key, nextPath } of toResolve) {
+    if (currentVal && typeof currentVal === 'object' && key in currentVal) {
+      const obj = currentVal as Record<string, unknown>;
+      results.push(...resolvePaths(obj[key], tail, nextPath));
+    }
+  }
+  return results;
+}
+
+export async function calculateIntegrity<
+  T extends Record<string, unknown>,
+  const P extends readonly string[],
+>(
+  payload: T,
+  paths: P,
+  hasher: DigestFn<T, P[number]>,
+): Promise<Integrity<T, P[number]>> {
+  const result = { ...payload } as Integrity<T, P[number]>;
+
+  const all = paths.flatMap((pathStr) => {
+    const segments = _splitPath(pathStr);
+    const matches = resolvePaths(payload, segments, '');
+    return matches.map(async ({ path, value }) => {
+      const key = `${path}#integrity`;
+      return {
+        [key]: await hasher(
+          key as IntegrityKeys<T, P[number]>,
+          value as PathValue<T, P[number]>,
+        ),
+      };
+    });
+  });
+
+  for (const obj of await Promise.all(all)) {
+    Object.assign(result, obj);
+  }
+
+  return result;
+}

--- a/packages/utils/src/integrity_parser.ts
+++ b/packages/utils/src/integrity_parser.ts
@@ -1,0 +1,144 @@
+import type { IntegrityHashAlg, IntegrityMetadata } from './integrity';
+import { _splitPath } from './integrity_calculator';
+
+/**
+ * SRI metadata digest string `alg-hash?options`.
+ */
+export interface IntegrityPart {
+  alg: IntegrityHashAlg;
+  hash: string;
+  /**
+   * The raw option expression string (without the leading '?').
+   */
+  options?: string;
+}
+
+export interface IntegrityPartError {
+  /**
+   * A description of the error that occurred parsing integrity or searching for the related value.
+   */
+  error: string;
+}
+
+/**
+ * Integrity check result should be considered invalid if value is undefined, or integrity has no valid parts, or any part that doesn't match the value hash
+ */
+export interface IntegrityCheckResult {
+  /** The specific key containing the integrity metadata */
+  key: string;
+  /** The raw value of the field for which the integrity exists, usually a string URI/URL */
+  value: unknown;
+  /** The parsed integrity parts, contains errored parts */
+  integrity: (IntegrityPart | IntegrityPartError)[];
+}
+
+/**
+ * Parses a single SRI string into its components.
+ * Strictly follows the "Parse metadata" algorithm from W3C SRI.
+ *
+ * @see https://www.w3.org/TR/sri-2/#parse-metadata
+ */
+export function parseIntegrityString(
+  input: IntegrityMetadata,
+): (IntegrityPart | IntegrityPartError)[] {
+  // 1. Let result be the empty set (allowing for errors).
+  const result: (IntegrityPart | IntegrityPartError)[] = [];
+
+  // 2. For each item returned by splitting metadata on spaces:
+  const items = input.trim().split(/\s+/);
+  for (const item of items) {
+    if (!item) continue;
+
+    // 3. Let expression-and-options be the result of splitting item on U+003F (?).
+    const expressionAndOptions = item.split('?');
+
+    // 4. Let algorithm-expression be expression-and-options[0].
+    const algorithmExpression = expressionAndOptions[0];
+
+    // 6. Let algorithm-and-value be the result of splitting algorithm-expression on U+002D (-).
+    const firstHyphenIndex = algorithmExpression.indexOf('-');
+
+    if (firstHyphenIndex === -1) {
+      result.push({
+        error: `Malformed integrity part '${item}': missing hyphen separator`,
+      });
+      continue;
+    }
+
+    // 7. Let algorithm be algorithm-and-value[0].
+    const algorithm = algorithmExpression.slice(
+      0,
+      firstHyphenIndex,
+    ) as IntegrityHashAlg;
+
+    if (!algorithm) {
+      result.push({
+        error: `Malformed integrity part '${item}': missing algorithm`,
+      });
+      continue;
+    }
+
+    // 8. If algorithm-and-value[1] exists, set base64-value to algorithm-and-value[1].
+    const base64Value = algorithmExpression.slice(firstHyphenIndex + 1);
+
+    // 9. Let metadata be the ordered map...
+    const options = expressionAndOptions[1]; // undefined if not present
+
+    // 10. Append metadata to result.
+    result.push({
+      alg: algorithm,
+      hash: base64Value,
+      options,
+    });
+  }
+
+  // 11. Return result.
+  return result;
+}
+
+/**
+ * Iterates over an object recursively, finds all keys ending in `#integrity`,
+ * and returns their parsed values associated with the related field's value.
+ * This function does not throw, it returns errors within its result.
+ */
+export function extractIntegrity(target: object): IntegrityCheckResult[] {
+  if (!target || typeof target !== 'object') return [];
+
+  return Object.entries(target).flatMap(([key, val]) => {
+    const err = (error: string) => [
+      {
+        key,
+        value: undefined,
+        integrity: [{ error }],
+      } satisfies IntegrityCheckResult,
+    ];
+
+    if (typeof val === 'object') return extractIntegrity(val);
+    if (!key.endsWith('#integrity')) return [];
+    const fullPath = key.replace(/#integrity$/, '');
+    if (!val || typeof val !== 'string') {
+      return err(
+        `sd-jwt integrity '${key}' should be string 'alg-hash?opt': ${JSON.stringify(val, undefined, 2)}`,
+      );
+    }
+    const rawValue = val as IntegrityMetadata;
+    const path = _splitPath(fullPath);
+    let value = target as Record<string, unknown>;
+    for (const step of path) {
+      if (typeof value === 'object' && step in value) {
+        value = value[step] as Record<string, unknown>;
+      } else {
+        return err(
+          `sd-jwt integrity for '${fullPath}' has no value in ${JSON.stringify(target, undefined, 2)}`,
+        );
+      }
+    }
+    return [
+      {
+        key,
+        value: value as unknown,
+        integrity: parseIntegrityString(rawValue),
+      },
+    ];
+  });
+}

--- a/packages/utils/src/test/integrity.spec.ts
+++ b/packages/utils/src/test/integrity.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import type { Integrity } from '../integrity';
+
+interface Credentials {
+  vct: string;
+  iss: string;
+  evidence: {
+    type: string;
+    document: {
+      id: string;
+    };
+  };
+  claims: {
+    given_name: string;
+    'family-name': string;
+  };
+  bank_accounts: Record<
+    string,
+    {
+      iban: string;
+    }
+  >;
+  'https://example.com/vocab': {
+    description: string;
+  };
+  arr: [string, string];
+}
+
+describe('Integrity Type Edge Cases', () => {
+  // 1. Root Level Simple Keys (NO LEADING DOT)
+  test('adds integrity fields for root properties without leading dots', () => {
+    type Result = Integrity<Credentials, 'vct' | 'iss'>;
+
+    expectTypeOf<Result>().toHaveProperty('vct#integrity');
+    expectTypeOf<Result>().toHaveProperty('iss#integrity');
+  });
+
+  // 2. Deep Nesting (Dot Notation)
+  test('handles deep dot notation correctly', () => {
+    type Result = Integrity<Credentials, 'evidence.document.id'>;
+
+    // Should look like "evidence.document.id#integrity", not ".evidence..."
+    expectTypeOf<Result>().toHaveProperty('evidence.document.id#integrity');
+  });
+
+  // 3. Bracket Notation for Special Characters
+  test('handles bracket notation for keys with hyphens', () => {
+    type Result = Integrity<Credentials, "claims['family-name']">;
+
+    // e.g. "claims['family-name']#integrity"
+    expectTypeOf<Result>().toHaveProperty("claims['family-name']#integrity");
+  });
+
+  // Bracket Notation for numbers
+  test('handles bracket notation for keys with hyphens', () => {
+    type Result = Integrity<Credentials, 'arr[*]'>;
+
+    // e.g. "claims['family-name']#integrity"
+    expectTypeOf<Result>().toHaveProperty('arr[0]#integrity');
+  });
+
+  // 4. Wildcard Expansion (*)
+  test('expands wildcards without leading dots', () => {
+    interface ConcreteBanks {
+      bank_accounts: {
+        chase: { iban: string };
+        other: { iban: string };
+      };
+    }
+    type Result = Integrity<ConcreteBanks, 'bank_accounts.*.iban'>;
+
+    expectTypeOf<Result>().toHaveProperty('bank_accounts.chase.iban#integrity');
+    expectTypeOf<Result>().toHaveProperty('bank_accounts.other.iban#integrity');
+  });
+
+  // 5. Complex URI Keys (Root Bracket Notation)
+  test('handles complex URI keys at the root', () => {
+    type Result = Integrity<
+      Credentials,
+      "['https://example.com/vocab'].description"
+    >;
+
+    // No dot before the first bracket
+    expectTypeOf<Result>().toHaveProperty(
+      "['https://example.com/vocab'].description#integrity",
+    );
+  });
+
+  // 6. Mixed Dot and Bracket Notation
+  test('parses mixed dot and bracket paths correctly', () => {
+    // Dot -> Bracket
+    type Res1 = Integrity<Credentials, "evidence['type']">;
+    // Normalized to dot notation if identifier is valid: "evidence.type"
+    expectTypeOf<Res1>().toHaveProperty('evidence.type#integrity');
+
+    // Bracket -> Dot
+    type Res2 = Integrity<Credentials, "claims['family-name']">;
+    expectTypeOf<Res2>().toHaveProperty("claims['family-name']#integrity");
+  });
+});

--- a/packages/utils/src/test/integrity_calculator.spec.ts
+++ b/packages/utils/src/test/integrity_calculator.spec.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { IntegrityDigest } from '../integrity';
+import { calculateIntegrity } from '../integrity_calculator';
+
+// --- Mock Data Setup ---
+
+const mockCredentials = {
+  vct: 'https://example.com/vct',
+  iss: 'https://example.com/iss',
+  evidence: {
+    type: 'document_check',
+    document: {
+      id: 'doc-123',
+    },
+  },
+  claims: {
+    given_name: 'John',
+    'family-name': 'Doe',
+  },
+  bank_accounts: {
+    chase: { iban: 'US123' },
+    'complex-bank': { iban: 'EU456' }, // Key requiring quotes
+  },
+  'https://example.com/vocab': {
+    description: 'A complex vocabulary',
+  },
+  arr: ['item1', 'item2'],
+  mixed_array: [{ id: 1 }, { id: 2 }],
+  nested_arrays: [
+    [1, 2],
+    [3, 4],
+  ],
+} as const;
+
+/**
+ * A generic mock hasher compatible with DigestFn<T, K>.
+ * It accepts (string, unknown) which satisfies the contravariance required
+ * for any specific (Key, Value) pair.
+ */
+const mockHasher = vi.fn(async (key: string, value: unknown) => {
+  const valString =
+    typeof value === 'object' && value !== null
+      ? JSON.stringify(value)
+      : String(value);
+  return `sha256-${key}?${valString}` as IntegrityDigest;
+});
+
+describe('Integrity Calculator', () => {
+  test('1. Root Level Simple Keys (Dot Notation)', async () => {
+    const result = await calculateIntegrity(
+      mockCredentials,
+      ['vct', 'iss'],
+      mockHasher,
+    );
+
+    expect(result).toHaveProperty('vct#integrity');
+    expect(result['vct#integrity']).toBe(
+      'sha256-vct#integrity?https://example.com/vct',
+    );
+
+    expect(result).toHaveProperty('iss#integrity');
+    expect(result['iss#integrity']).toBe(
+      'sha256-iss#integrity?https://example.com/iss',
+    );
+  });
+
+  test('2. Deep Nesting (Dot Notation)', async () => {
+    const result = await calculateIntegrity(
+      mockCredentials,
+      ['evidence.document.id'],
+      mockHasher,
+    );
+
+    expect(result).toHaveProperty('evidence.document.id#integrity');
+    expect(result['evidence.document.id#integrity']).toContain('doc-123');
+  });
+
+  test('3. Bracket Notation (Explicit Paths)', async () => {
+    // Testing single quotes ['...'] and double quotes ["..."]
+    const result = await calculateIntegrity(
+      mockCredentials,
+      ["claims['family-name']", 'claims["given_name"]'],
+      mockHasher,
+    );
+
+    // 1. 'family-name' contains a hyphen (invalid identifier), so brackets MUST be preserved.
+    // Matches Type: claims['family-name']#integrity
+    expect(result).toHaveProperty("claims['family-name']#integrity");
+    expect(result["claims['family-name']#integrity"]).toContain('Doe');
+
+    // 2. 'given_name' is a valid identifier, so it MUST be normalized to dot notation.
+    // Matches Type: claims.given_name#integrity
+    expect(result).toHaveProperty('claims.given_name#integrity');
+    expect(result['claims.given_name#integrity']).toContain('John');
+  });
+
+  test('4. Array Indices (Explicit)', async () => {
+    const result = await calculateIntegrity(
+      mockCredentials,
+      ['arr[0]', 'arr[1]'],
+      mockHasher,
+    );
+
+    expect(result).toHaveProperty('arr[0]#integrity');
+    expect(result['arr[0]#integrity']).toContain('item1');
+    expect(result['arr[1]#integrity']).toContain('item2');
+  });
+
+  test('5. Wildcard Expansion (*) on Objects (Normalization Check)', async () => {
+    // This tests the normalization logic in resolvePaths for wildcards
+    // It should handle simple keys (chase) -> .chase
+    // And complex keys (complex-bank) -> ['complex-bank']
+    const result = await calculateIntegrity(
+      mockCredentials,
+      ['bank_accounts.*.iban'],
+      mockHasher,
+    );
+
+    // Simple Identifier
+    expect(result).toHaveProperty('bank_accounts.chase.iban#integrity');
+    expect(result['bank_accounts.chase.iban#integrity']).toContain('US123');
+
+    // Complex Identifier (Normalized to brackets)
+    expect(result).toHaveProperty(
+      "bank_accounts['complex-bank'].iban#integrity",
+    );
+    expect(result["bank_accounts['complex-bank'].iban#integrity"]).toContain(
+      'EU456',
+    );
+  });
+
+  test('6. Wildcard Expansion [*] on Arrays', async () => {
+    const result = await calculateIntegrity(
+      mockCredentials,
+      ['arr[*]'],
+      mockHasher,
+    );
+
+    expect(result).toHaveProperty('arr[0]#integrity');
+    expect(result['arr[0]#integrity']).toContain('item1');
+    expect(result['arr[1]#integrity']).toContain('item2');
+  });
+
+  test('7. Mixed Dot and Bracket Notation', async () => {
+    const result = await calculateIntegrity(
+      mockCredentials,
+      ["evidence['document'].id"], // Mixed brackets and dots
+      mockHasher,
+    );
+
+    // Runtime concatenates explicitly provided mixed paths
+    expect(result).toHaveProperty('evidence.document.id#integrity');
+    expect(result['evidence.document.id#integrity']).toContain('doc-123');
+  });
+
+  test('8. Complex Root Keys (URI keys)', async () => {
+    const result = await calculateIntegrity(
+      mockCredentials,
+      ["['https://example.com/vocab'].description"],
+      mockHasher,
+    );
+
+    expect(result).toHaveProperty(
+      "['https://example.com/vocab'].description#integrity",
+    );
+    expect(
+      result["['https://example.com/vocab'].description#integrity"],
+    ).toContain('complex vocabulary');
+  });
+
+  test('9. Missing Keys (Graceful Handling)', async () => {
+    const result = await calculateIntegrity(
+      mockCredentials,
+      ['non_existent.field', 'evidence.missing_prop'],
+      mockHasher,
+    );
+
+    // Should return the original object without crashing
+    expect(result).toBeDefined();
+    expect(result).not.toHaveProperty('non_existent.field#integrity');
+  });
+
+  test('10. Wildcard on Non-Object/Null (Safety Check)', async () => {
+    const payload = {
+      primitive: 123,
+      nullVal: null,
+    };
+
+    const result = await calculateIntegrity(
+      payload,
+      ['primitive.*', 'nullVal.*'],
+      mockHasher,
+    );
+
+    // Should not crash and not add fields
+    expect(result).toEqual(payload);
+  });
+
+  test('11. Regex Edge Cases and Nested Wildcards', async () => {
+    const nestedMock = {
+      matrix: [
+        [10, 11],
+        [20, 21],
+      ],
+    };
+
+    const result = await calculateIntegrity(
+      nestedMock,
+      ['matrix[*][*]'], // Double wildcard
+      mockHasher,
+    );
+
+    expect(result).toHaveProperty('matrix[0][0]#integrity');
+    expect(result).toHaveProperty('matrix[0][1]#integrity');
+    expect(result).toHaveProperty('matrix[1][0]#integrity');
+    expect(result).toHaveProperty('matrix[1][1]#integrity');
+    expect(result['matrix[0][0]#integrity']).toContain('10');
+  });
+
+  test('12. Hasher Interaction', async () => {
+    const spy = vi.fn(() => 'sha256-mock' as IntegrityDigest);
+    await calculateIntegrity({ a: 1 }, ['a'], spy);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('a#integrity', 1);
+  });
+
+  test('13. Wildcard Normalization with Numeric Keys', async () => {
+    // Specifically testing the /^[0-9]*$/ regex branch in wildcard expansion
+    const numKeyObj = {
+      data: {
+        '123': 'value',
+        normal: 'value',
+      },
+    };
+
+    const result = await calculateIntegrity(numKeyObj, ['data.*'], mockHasher);
+
+    // Should normalize "123" to [123] NOT .123 or ['123']
+    expect(result).toHaveProperty('data[123]#integrity');
+    // Standard key check
+    expect(result).toHaveProperty('data.normal#integrity');
+  });
+});

--- a/packages/utils/src/test/integrity_parser.spec.ts
+++ b/packages/utils/src/test/integrity_parser.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'vitest';
+import type { IntegrityMetadata } from '../integrity';
+import { extractIntegrity, parseIntegrityString } from '../integrity_parser';
+
+describe('Integrity Parser', () => {
+  describe('parseIntegrityString', () => {
+    test('parses W3C SRI format correctly', () => {
+      const input = 'sha256-AbCd?opt=1' as IntegrityMetadata;
+      const result = parseIntegrityString(input);
+      expect(result[0]).toEqual({
+        alg: 'sha256',
+        hash: 'AbCd',
+        options: 'opt=1',
+      });
+    });
+  });
+
+  describe('extractIntegrity', () => {
+    test('resolves simple sibling values', () => {
+      const payload = {
+        name: 'Alice',
+        'name#integrity': 'sha256-hash1',
+      };
+
+      const results = extractIntegrity(payload);
+      expect(results).toHaveLength(1);
+      expect(results[0].key).toBe('name#integrity');
+      expect(results[0].value).toBe('Alice');
+      expect(results[0].integrity[0]).haveOwnProperty('hash', 'hash1');
+    });
+
+    test('resolves nested dot-notation paths from root', () => {
+      const payload = {
+        claims: {
+          sub: '123',
+        },
+        'claims.sub#integrity': 'sha256-hashSub',
+      };
+
+      const results = extractIntegrity(payload);
+      expect(results[0].key).toBe('claims.sub#integrity');
+      expect(results[0].value).toBe('123'); // Resolved path claims.sub
+    });
+
+    test('resolves bracket-notation paths', () => {
+      const payload = {
+        claims: {
+          'family-name': 'Doe',
+        },
+        "claims['family-name']#integrity": 'sha256-hashDoe',
+      };
+
+      const results = extractIntegrity(payload);
+      expect(results[0].key).toBe("claims['family-name']#integrity");
+      expect(results[0].value).toBe('Doe');
+    });
+
+    test('searches recursively at every object level', () => {
+      const payload = {
+        // Level 1: Root integrity
+        top: 'level',
+        'top#integrity': 'sha256-top',
+
+        nested: {
+          // Level 2: Nested integrity
+          leaf: 'value',
+          'leaf#integrity': 'sha256-leaf',
+
+          deep: {
+            // Level 3
+            id: 99,
+            'id#integrity': 'sha256-id',
+          },
+        },
+      };
+
+      const results = extractIntegrity(payload);
+      expect(results).toHaveLength(3);
+
+      const top = results.find((r) => r.key === 'top#integrity');
+      expect(top?.value).toBe('level');
+
+      const leaf = results.find((r) => r.key === 'leaf#integrity');
+      expect(leaf?.value).toBe('value'); // Resolved relative to 'nested' object
+
+      const id = results.find((r) => r.key === 'id#integrity');
+      expect(id?.value).toBe(99); // Resolved relative to 'nested.deep' object
+    });
+
+    test('handles path resolution failure gracefully (undefined value)', () => {
+      const payload = {
+        'missing#integrity': 'sha256-hash',
+      };
+
+      const results = extractIntegrity(payload);
+      expect(results[0].key).toBe('missing#integrity');
+      expect(results[0].value).toBeUndefined();
+    });
+
+    test('ignores non-integrity fields', () => {
+      const payload = { a: 1, b: 2 };
+      expect(extractIntegrity(payload)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
This may deserve its own separate package, let me know if i should extract it, only IntegrityMetadata and IntegrityDigest is required in utils

### Added Section 7 of [SD-JWT-VC] compliant integrity helpers

* **Types:**
    * Improved types for `#integrity` fields that hint to the structure: `alg-hash?options`.
    * `Integrity<T, K>` helper type that automatically defines integrity fields based on `K` (e.g., `'field_path[*].etc' | 'other_field'`).
    * Strongly typed `IntegrityMetadata` and `IntegrityDigest` to enforce the W3C SRI format (e.g., `${Algorithm}-${string}`).
* **Calculation:**
    * `calculateIntegrity` runtime utility to compute and inject integrity hashes into an object.
    * Support for JSONPath-like selectors including Dot Notation (`a.b`), Bracket Notation (`['a']`, `[0]`), and Wildcards (`*`, `[*]`) for arrays and objects.
    * **Automatic path normalization** (e.g., converting valid identifiers in brackets to dot notation where appropriate) to ensure consistent integrity keys.
* **Parsing & Extraction:**
    * `parseIntegrityString` implementation strictly following the W3C SRI standard (SRI 2, Section 3.3.2).
    * Support for multiple whitespace-separated hash expressions and optional parameters.
    * `extractIntegrity` utility that recursively traverses an object tree to find all `#integrity` fields and pairs every found integrity hash with its actual protected value from the payload, handling nested relative paths.
    * Structured error handling (`IntegrityPartError`) for malformed SRI strings (e.g., missing algorithms or separators).
    

### Usage Example

This example demonstrates how to define a secured type, calculate integrity hashes for specific fields (including nested objects and arrays), and then extract those hashes for verification.

#### 1. Define the Data Structure & Secured Type

Use the `Integrity<T, K>` utility to automatically add optional `#integrity` fields to your base type.

```typescript
import type { Integrity } from './integrity';

// 1. Base Interface
interface UserProfile {
  id: string;
  username: string;
  contact: {
    email: string;
    phone?: string;
  };
  documents: {
    type: string;
    url: string;
  }[];
}

// 2. Define Secured Type
// Automatically adds:
// - contact.email#integrity
// - documents[*].url#integrity
type SecuredProfile = Integrity<
  UserProfile,
  'contact.email' | 'documents[*].url'
>;

```

#### 2. Calculate Integrity

Use `calculateIntegrity` to compute hashes for the specified paths. You need to provide a hashing function (e.g., using standard Web Crypto API).

```typescript
import { calculateIntegrity } from './integrity_calculator';

// Mock Hasher (Replace with real crypto logic, e.g., sha256)
const myHasher = async (key: string, value: unknown) => {
  const content = String(value);
  // In reality: await crypto.subtle.digest(..., content)
  return `sha256-hashOf(${content})` as const;
};

const user: UserProfile = {
  id: 'user_123',
  username: 'alice_dev',
  contact: {
    email: 'alice@example.com',
  },
  documents: [
    { type: 'id_card', url: 'https://storage.api/doc/1' },
    { type: 'utility_bill', url: 'https://storage.api/doc/2' },
  ],
};

// 3. Compute Hashes
const securedUser = await calculateIntegrity(
  user,
  ['contact.email', 'documents[*].url'],
  myHasher
);

console.log(securedUser);
/* Output:
{
  ...user,
  'contact.email#integrity': 'sha256-hashOf(alice@example.com)',
  'documents[0].url#integrity': 'sha256-hashOf(https://storage.api/doc/1)',
  'documents[1].url#integrity': 'sha256-hashOf(https://storage.api/doc/2)' 
}
*/

```

#### 3. Extract & Verify

Use `extractIntegrity` to find all integrity fields in the payload and resolve the values they protect.

```typescript
import { extractIntegrity } from './integrity_parser';

// 4. Parse and Extract
const results = extractIntegrity(securedUser);

results.forEach((check) => {
  console.log(`Key: ${check.key}`);
  console.log(`Protected Value: ${check.value}`);
  
  check.integrity.forEach((part) => {
    if ('error' in part) {
      console.error(`Error: ${part.error}`);
    } else {
      console.log(`Algorithm: ${part.alg}`);
      console.log(`Hash: ${part.hash}`);
    }
  });
  console.log('---');
});

/* Output:
Key: contact.email#integrity
Protected Value: alice@example.com
Algorithm: sha256
Hash: hashOf(alice@example.com)
---
Key: documents[0].url#integrity
Protected Value: https://storage.api/doc/1
Algorithm: sha256
Hash: hashOf(https://storage.api/doc/1)
...
*/

```

This is an example applicable to [ts12](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts12-electronic-payments-SCA-implementation-with-wallet.md#412-metadata-integrity-verification) but `calculateIntegrity` can also be manually nested if integrity is supposed to be nested for sd-jwt-metadata fields for instance. No special handling is needed for verification, it tests all possible locations and combinations recursively