### PR TITLE
feat(sd-jwt-vc)!: implement type metadata extends resolving and merging

### DIFF
--- a/packages/sd-jwt-vc/src/sd-jwt-vc-config.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-config.ts
@@ -20,4 +20,6 @@ export type SDJWTVCConfig = SDJWTConfig & {
   loadTypeMetadataFormat?: boolean;
   // timeout value in milliseconds when to abort the fetch request. If not provided, it will default to 10000.
   timeout?: number;
+  // maximum depth of extends chain to resolve. If not provided, it will default to 5. Set to -1 to not limit the vct extends depth.
+  maxVctExtendsDepth?: number;
 };

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -13,7 +13,12 @@ import type {
   StatusValidator,
 } from './sd-jwt-vc-config';
 import type { SdJwtVcPayload } from './sd-jwt-vc-payload';
-import type { TypeMetadataFormat } from './sd-jwt-vc-type-metadata-format';
+import type {
+  Claim,
+  ClaimPath,
+  ResolvedTypeMetadata,
+  TypeMetadataFormat,
+} from './sd-jwt-vc-type-metadata-format';
 import type { VcTFetcher } from './sd-jwt-vc-vct';
 import type { VerificationResult } from './verification-result';
 
@@ -121,7 +126,8 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
 
     await this.verifyStatus(result, options);
     if (this.userConfig.loadTypeMetadataFormat) {
-      await this.verifyVct(result);
+      const resolvedTypeMetadata = await this.fetchVct(result);
+      result.typeMetadata = resolvedTypeMetadata;
     }
     return result;
   }
@@ -134,7 +140,9 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
    * @param encodedSDJwt
    * @returns
    */
-  async getVct(encodedSDJwt: string): Promise<TypeMetadataFormat | undefined> {
+  async getVct(
+    encodedSDJwt: string,
+  ): Promise<ResolvedTypeMetadata | undefined> {
     // Call the parent class's verify method
     const { payload, header } = await SDJwt.extractJwt<
       Record<string, unknown>,
@@ -213,20 +221,241 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
 
   /**
    * Verifies the VCT of the SD-JWT-VC. Returns the type metadata format.
+   * Resolves the full extends chain according to spec sections 6.4, 8.2, and 9.5.
    * @param result
    * @returns
    */
-  private async verifyVct(
+  private async fetchVct(
     result: VerificationResult,
-  ): Promise<TypeMetadataFormat | undefined> {
-    const typeMetadataFormat = await this.fetchVct(result);
+  ): Promise<ResolvedTypeMetadata | undefined> {
+    const typeMetadataFormat = await this.fetchSingleVct(result);
 
-    if (typeMetadataFormat?.extends) {
-      // implement based on https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-08.html#name-extending-type-metadata
-      //TODO: needs to be implemented. Unclear at this point which values will overwrite the values from the extended type metadata format
+    if (!typeMetadataFormat) return undefined;
+
+    // If there's no extends
+    if (!typeMetadataFormat.extends) {
+      return {
+        mergedTypeMetadata: typeMetadataFormat,
+        typeMetadataChain: [typeMetadataFormat],
+        vctValues: [typeMetadataFormat.vct],
+      };
     }
 
-    return typeMetadataFormat;
+    // Resolve the full VCT chain if extends is present
+    return this.resolveVctExtendsChain(typeMetadataFormat);
+  }
+
+  /**
+   * Checks if two claim paths are equal by comparing each element.
+   * @param path1 First claim path
+   * @param path2 Second claim path
+   * @returns True if paths are equal, false otherwise
+   */
+  private claimPathsEqual(path1: ClaimPath, path2: ClaimPath): boolean {
+    if (path1.length !== path2.length) return false;
+    return path1.every((element, index) => element === path2[index]);
+  }
+
+  /**
+   * Validates that extending claim metadata respects the constraints from spec section 9.5.1.
+   * @param baseClaim The base claim metadata
+   * @param extendingClaim The extending claim metadata
+   * @throws SDJWTException if validation fails
+   */
+  private validateClaimExtension(
+    baseClaim: Claim,
+    extendingClaim: Claim,
+  ): void {
+    // Validate 'sd' property constraints (section 9.5.1)
+    if (baseClaim.sd && extendingClaim.sd) {
+      // Cannot change from 'always' or 'never' to a different value
+      if (
+        (baseClaim.sd === 'always' || baseClaim.sd === 'never') &&
+        baseClaim.sd !== extendingClaim.sd
+      ) {
+        const pathStr = JSON.stringify(extendingClaim.path);
+        throw new SDJWTException(
+          `Cannot change 'sd' property from '${baseClaim.sd}' to '${extendingClaim.sd}' for claim at path ${pathStr}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Merges two type metadata formats, with the extending metadata overriding the base metadata.
+   * According to spec section 9.5:
+   * - All claim metadata from the extended type are inherited
+   * - The child type can add new claims or properties
+   * - If the child type defines claim metadata with the same path as the extended type,
+   *   the child type's object will override the corresponding object from the extended type
+   * According to spec section 9.5.1:
+   * - sd property can only be changed from 'allowed' (or omitted) to 'always' or 'never'
+   * - sd property cannot be changed from 'always' or 'never' to a different value
+   * According to spec section 8.2:
+   * - If the extending type defines its own display property, the original display metadata is ignored
+   * Note: The spec also mentions 'mandatory' property constraints, but this is not currently
+   * defined in the Claim type and will be validated when that property is added to the type.
+   * @param base The base type metadata format
+   * @param extending The extending type metadata format
+   * @returns The merged type metadata format
+   */
+  private mergeTypeMetadata(
+    base: TypeMetadataFormat,
+    extending: TypeMetadataFormat,
+  ): TypeMetadataFormat {
+    // Start with a shallow copy of the extending metadata
+    // All properties that don't have explicit processing logic for merging
+    // will only be shallow copied, and the extending metadata will take precedence.
+    const merged: TypeMetadataFormat = { ...extending };
+
+    // Merge claims arrays if both exist
+    if (base.claims || extending.claims) {
+      const baseClaims = base.claims ?? [];
+      const extendingClaims = extending.claims ?? [];
+
+      // Validate extending claims that override base claims
+      for (const extendingClaim of extendingClaims) {
+        const matchingBaseClaim = baseClaims.find((baseClaim) =>
+          this.claimPathsEqual(baseClaim.path, extendingClaim.path),
+        );
+
+        if (matchingBaseClaim) {
+          this.validateClaimExtension(matchingBaseClaim, extendingClaim);
+        }
+      }
+
+      // Build final claims array preserving order
+      // Start with base claims, replacing any that are overridden
+      const mergedClaims: typeof baseClaims = [];
+      const extendedClaimsWithoutBase = [...extendingClaims];
+
+      // Add base claims, replacing with extending version if path matches
+      for (const baseClaim of baseClaims) {
+        const extendingClaimIndex = extendedClaimsWithoutBase.findIndex(
+          (extendingClaim) =>
+            this.claimPathsEqual(baseClaim.path, extendingClaim.path),
+        );
+        const extendingClaim =
+          extendingClaimIndex !== -1
+            ? extendedClaimsWithoutBase[extendingClaimIndex]
+            : undefined;
+
+        // Remove item from the array
+        if (extendingClaim) {
+          extendedClaimsWithoutBase.splice(extendingClaimIndex, 1);
+        }
+
+        // Prefer extending claim, otherwise use base claim
+        mergedClaims.push(extendingClaim ?? baseClaim);
+      }
+
+      // Add all remaining claims at the end
+      mergedClaims.push(...extendedClaimsWithoutBase);
+
+      merged.claims = mergedClaims;
+    }
+
+    // Handle display metadata (section 8.2)
+    // If extending type doesn't define display, inherit from base
+    if (!extending.display && base.display) {
+      merged.display = base.display;
+    }
+
+    return merged;
+  }
+
+  /**
+   * Resolves the full VCT chain by recursively fetching extended type metadata.
+   * Implements security considerations from spec section 10.3 for circular dependencies.
+   * @param vct The VCT URI to resolve
+   * @param integrity Optional integrity metadata for the VCT
+   * @param depth Current depth in the chain
+   * @param visitedVcts Set of already visited VCT URIs to detect circular dependencies
+   * @returns The fully resolved and merged type metadata format
+   */
+  private async resolveVctExtendsChain(
+    parentTypeMetadata: TypeMetadataFormat,
+    // We start at one, as the base is already fetched when this method is first called
+    depth: number = 1,
+    // By default include the parent vct, in case of the first call
+    visitedVcts: Set<string> = new Set(parentTypeMetadata.vct),
+  ): Promise<ResolvedTypeMetadata> {
+    const maxDepth = this.userConfig.maxVctExtendsDepth ?? 5;
+
+    // Check max depth (security consideration from spec section 10.3)
+    if (maxDepth !== -1 && depth > maxDepth) {
+      throw new SDJWTException(
+        `Maximum VCT extends depth of ${maxDepth} exceeded`,
+      );
+    }
+
+    if (!parentTypeMetadata.extends) {
+      throw new SDJWTException(
+        `Type metadata for vct '${parentTypeMetadata.vct}' has no 'extends' field. Unable to resolve extended type metadata document.`,
+      );
+    }
+
+    // Check for circular dependencies (security consideration from spec section 10.3)
+    if (visitedVcts.has(parentTypeMetadata.extends)) {
+      throw new SDJWTException(
+        `Circular dependency detected in VCT extends chain: ${parentTypeMetadata.extends}`,
+      );
+    }
+
+    // Mark this VCT as visited
+    visitedVcts.add(parentTypeMetadata.extends);
+
+    // Fetch the type metadata
+    const fetcher: VcTFetcher =
+      this.userConfig.vctFetcher ??
+      ((uri, integrity) => this.fetch(uri, integrity));
+
+    const extendedTypeMetadata = await fetcher(
+      parentTypeMetadata.extends,
+      parentTypeMetadata['extends#integrity'],
+    );
+
+    // While top-level vct MAY return null (meaning there's no vct type metadata)
+    // The extends value ALWAYS must resolve to a value. A custom user provided resolver
+    // can return a minimal on-demand type metadata document if it wants to support this use case
+    if (!extendedTypeMetadata) {
+      throw new SDJWTException(
+        `Resolving VCT extends value '${parentTypeMetadata.extends}' resulted in an undefined result.`,
+      );
+    }
+
+    let resolvedTypeMetadata: ResolvedTypeMetadata;
+
+    // If this type extends another, recursively resolve the chain
+    //  We MUST first process the lower level document before processing
+    // the higher level document
+    if (extendedTypeMetadata.extends) {
+      resolvedTypeMetadata = await this.resolveVctExtendsChain(
+        extendedTypeMetadata,
+        depth + 1,
+        visitedVcts,
+      );
+    } else {
+      resolvedTypeMetadata = {
+        mergedTypeMetadata: extendedTypeMetadata,
+        typeMetadataChain: [extendedTypeMetadata],
+        vctValues: [extendedTypeMetadata.vct],
+      };
+    }
+
+    const mergedTypeMetadata = this.mergeTypeMetadata(
+      resolvedTypeMetadata.mergedTypeMetadata,
+      parentTypeMetadata,
+    );
+
+    return {
+      mergedTypeMetadata: mergedTypeMetadata,
+      typeMetadataChain: [
+        parentTypeMetadata,
+        ...resolvedTypeMetadata.typeMetadataChain,
+      ],
+      vctValues: [parentTypeMetadata.vct, ...resolvedTypeMetadata.vctValues],
+    };
   }
 
   /**
@@ -234,7 +463,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
    * @param result
    * @returns
    */
-  private async fetchVct(
+  private async fetchSingleVct(
     result: VerificationResult,
   ): Promise<TypeMetadataFormat | undefined> {
     if (!result.payload.vct) {

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-type-metadata-format.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-type-metadata-format.ts
@@ -142,3 +142,25 @@ export type TypeMetadataFormat = {
   /** OPTIONAL. Array of claim metadata. */
   claims?: Claim[];
 };
+
+/**
+ * The resolved type metadata. If you just want to use the type metadata, you should use `typeMetadata`.
+ * In case additional processing is needed (e.g. for extensions in type metadata), you can use the `typeMetadataChain`
+ */
+export type ResolvedTypeMetadata = {
+  /**
+   * The merged type metadata based on the resolved `vct` document and all `extends` values.
+   */
+  mergedTypeMetadata: TypeMetadataFormat;
+
+  /**
+   * The original type metadata documents, ordered from the extending type to the last extended type.
+   */
+  typeMetadataChain: [TypeMetadataFormat, ...TypeMetadataFormat[]];
+
+  /**
+   * The vct values present in the type metadata chain. This can be used for matching against e.g.
+   * DCQL queries which can query an underlying type.
+   */
+  vctValues: [string, ...string[]];
+};

--- a/packages/sd-jwt-vc/src/test/vct.spec.ts
+++ b/packages/sd-jwt-vc/src/test/vct.spec.ts
@@ -15,6 +15,131 @@ const exampleVctm = {
   description: 'An example credential type',
 };
 
+const baseVctm: TypeMetadataFormat = {
+  vct: 'http://example.com/base',
+  name: 'BaseCredentialType',
+  description: 'A base credential type',
+  claims: [
+    {
+      path: ['firstName'],
+      display: [{ lang: 'en', label: 'First Name' }],
+    },
+  ],
+  display: [
+    {
+      lang: 'en',
+      name: 'Base Credential',
+      description: 'Base description',
+    },
+  ],
+};
+
+const extendingVctm: TypeMetadataFormat = {
+  vct: 'http://example.com/extending',
+  name: 'ExtendingCredentialType',
+  description: 'A credential type that extends the base',
+  extends: 'http://example.com/base',
+  claims: [
+    {
+      path: ['lastName'],
+      display: [{ lang: 'en', label: 'Last Name' }],
+    },
+  ],
+  display: [
+    {
+      lang: 'en',
+      name: 'Extended Credential',
+      description: 'Extended description',
+    },
+    {
+      lang: 'de',
+      name: 'Erweiterte Berechtigung',
+      description: 'Erweiterte Beschreibung',
+    },
+  ],
+};
+
+const middleVctm: TypeMetadataFormat = {
+  vct: 'http://example.com/middle',
+  name: 'MiddleCredentialType',
+  description: 'Middle type in chain',
+  extends: 'http://example.com/extending',
+  claims: [
+    {
+      path: ['age'],
+      display: [{ lang: 'en', label: 'Age' }],
+    },
+  ],
+};
+
+const overridingVctm: TypeMetadataFormat = {
+  vct: 'http://example.com/overriding',
+  name: 'OverridingCredentialType',
+  description: 'A credential type that overrides a claim from the base',
+  extends: 'http://example.com/base',
+  claims: [
+    {
+      path: ['firstName'],
+      display: [{ lang: 'en', label: 'Given Name' }], // Override with different label
+      sd: 'always' as const,
+    },
+    {
+      path: ['middleName'],
+      display: [{ lang: 'en', label: 'Middle Name' }],
+    },
+  ],
+};
+
+const circularVctm: TypeMetadataFormat = {
+  vct: 'http://example.com/circular',
+  name: 'CircularCredentialType',
+  extends: 'http://example.com/circular',
+};
+
+const deepVctm: TypeMetadataFormat = {
+  vct: 'http://example.com/deep',
+  name: 'DeepCredentialType',
+  extends: 'http://example.com/middle',
+};
+
+const baseWithSdAlways: TypeMetadataFormat = {
+  vct: 'http://example.com/base-sd-always',
+  name: 'BaseWithSdAlways',
+  claims: [
+    {
+      path: ['sensitiveData'],
+      sd: 'always' as const,
+      display: [{ lang: 'en', label: 'Sensitive Data' }],
+    },
+  ],
+};
+
+const invalidExtendingSdChange: TypeMetadataFormat = {
+  vct: 'http://example.com/invalid-sd-change',
+  name: 'InvalidSdChange',
+  extends: 'http://example.com/base-sd-always',
+  claims: [
+    {
+      path: ['sensitiveData'],
+      sd: 'never' as const, // Invalid: trying to change from 'always' to 'never'
+      display: [{ lang: 'en', label: 'Sensitive Data' }],
+    },
+  ],
+};
+
+const validExtendingSdChange: TypeMetadataFormat = {
+  vct: 'http://example.com/valid-sd-change',
+  name: 'ValidSdChange',
+  extends: 'http://example.com/base',
+  claims: [
+    {
+      path: ['firstName'],
+      sd: 'always' as const, // Valid: base doesn't have sd or has 'allowed'
+      display: [{ lang: 'en', label: 'First Name' }],
+    },
+  ],
+};
+
 const restHandlers = [
   http.get('http://example.com/example', () => {
     const res: TypeMetadataFormat = exampleVctm;
@@ -26,6 +151,33 @@ const restHandlers = [
         resolve(HttpResponse.json({}));
       }, 10000);
     });
+  }),
+  http.get('http://example.com/base', () => {
+    return HttpResponse.json(baseVctm);
+  }),
+  http.get('http://example.com/extending', () => {
+    return HttpResponse.json(extendingVctm);
+  }),
+  http.get('http://example.com/middle', () => {
+    return HttpResponse.json(middleVctm);
+  }),
+  http.get('http://example.com/overriding', () => {
+    return HttpResponse.json(overridingVctm);
+  }),
+  http.get('http://example.com/circular', () => {
+    return HttpResponse.json(circularVctm);
+  }),
+  http.get('http://example.com/deep', () => {
+    return HttpResponse.json(deepVctm);
+  }),
+  http.get('http://example.com/base-sd-always', () => {
+    return HttpResponse.json(baseWithSdAlways);
+  }),
+  http.get('http://example.com/invalid-sd-change', () => {
+    return HttpResponse.json(invalidExtendingSdChange);
+  }),
+  http.get('http://example.com/valid-sd-change', () => {
+    return HttpResponse.json(validExtendingSdChange);
   }),
 ];
 
@@ -163,13 +315,346 @@ describe('App', () => {
       disclosureFrame as unknown as DisclosureFrame<SdJwtVcPayload>,
     );
 
-    const typeMetadataFormat = await sdjwt.getVct(encodedSdjwt);
-    expect(typeMetadataFormat).to.deep.eq({
+    const resolvedTypeMetadata = await sdjwt.getVct(encodedSdjwt);
+
+    // Check mergedTypeMetadata
+    expect(resolvedTypeMetadata?.mergedTypeMetadata).to.deep.eq({
       description: 'An example credential type',
       name: 'ExampleCredentialType',
       vct: 'http://example.com/example',
     });
+
+    // Check typeMetadataChain - should have only one document (no extends)
+    expect(resolvedTypeMetadata?.typeMetadataChain).toHaveLength(1);
+    expect(resolvedTypeMetadata?.typeMetadataChain[0].vct).toBe(
+      'http://example.com/example',
+    );
+
+    // Check vctValues - should have only one value
+    expect(resolvedTypeMetadata?.vctValues).toHaveLength(1);
+    expect(resolvedTypeMetadata?.vctValues[0]).toBe(
+      'http://example.com/example',
+    );
   });
 
-  //TODO: we need tests with an embedded schema, extended and maybe also to test the errors when schema information is not available or the integrity is not valid
+  test('VCT with extends - simple chain', async () => {
+    const expectedPayload: SdJwtVcPayload = {
+      iat,
+      iss,
+      vct: 'http://example.com/extending',
+      ...claims,
+    };
+
+    const encodedSdjwt = await sdjwt.issue(
+      expectedPayload,
+      disclosureFrame as unknown as DisclosureFrame<SdJwtVcPayload>,
+    );
+
+    const resolvedTypeMetadata = await sdjwt.getVct(encodedSdjwt);
+
+    // Check mergedTypeMetadata - should merge claims from both base and extending types
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims).toHaveLength(2);
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims?.[0].path).toEqual([
+      'firstName',
+    ]);
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims?.[1].path).toEqual([
+      'lastName',
+    ]);
+
+    // Display from extending type completely replaces base display (section 8.2)
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.display).toHaveLength(2);
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.display?.[0]).toEqual({
+      lang: 'en',
+      name: 'Extended Credential',
+      description: 'Extended description',
+    });
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.display?.[1]).toEqual({
+      lang: 'de',
+      name: 'Erweiterte Berechtigung',
+      description: 'Erweiterte Beschreibung',
+    });
+
+    // Top-level properties should come from extending type
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.name).toBe(
+      'ExtendingCredentialType',
+    );
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.description).toBe(
+      'A credential type that extends the base',
+    );
+
+    // Check typeMetadataChain - should have 2 documents in chain
+    expect(resolvedTypeMetadata?.typeMetadataChain).toHaveLength(2);
+    expect(resolvedTypeMetadata?.typeMetadataChain[0].vct).toBe(
+      'http://example.com/extending',
+    );
+    expect(resolvedTypeMetadata?.typeMetadataChain[1].vct).toBe(
+      'http://example.com/base',
+    );
+
+    // Check vctValues - should have 2 values
+    expect(resolvedTypeMetadata?.vctValues).toHaveLength(2);
+    expect(resolvedTypeMetadata?.vctValues[0]).toBe(
+      'http://example.com/extending',
+    );
+    expect(resolvedTypeMetadata?.vctValues[1]).toBe('http://example.com/base');
+  });
+
+  test('VCT with extends - multi-level chain', async () => {
+    const expectedPayload: SdJwtVcPayload = {
+      iat,
+      iss,
+      vct: 'http://example.com/middle',
+      ...claims,
+    };
+
+    const encodedSdjwt = await sdjwt.issue(
+      expectedPayload,
+      disclosureFrame as unknown as DisclosureFrame<SdJwtVcPayload>,
+    );
+
+    const resolvedTypeMetadata = await sdjwt.getVct(encodedSdjwt);
+
+    // Check mergedTypeMetadata - should merge claims from base -> extending -> middle
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims).toHaveLength(3);
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims?.[0].path).toEqual([
+      'firstName',
+    ]);
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims?.[1].path).toEqual([
+      'lastName',
+    ]);
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims?.[2].path).toEqual([
+      'age',
+    ]);
+
+    // Top-level properties should come from the most derived type
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.name).toBe(
+      'MiddleCredentialType',
+    );
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.description).toBe(
+      'Middle type in chain',
+    );
+
+    // Check typeMetadataChain - should have 3 documents in chain
+    expect(resolvedTypeMetadata?.typeMetadataChain).toHaveLength(3);
+    expect(resolvedTypeMetadata?.typeMetadataChain[0].vct).toBe(
+      'http://example.com/middle',
+    );
+    expect(resolvedTypeMetadata?.typeMetadataChain[1].vct).toBe(
+      'http://example.com/extending',
+    );
+    expect(resolvedTypeMetadata?.typeMetadataChain[2].vct).toBe(
+      'http://example.com/base',
+    );
+
+    // Check vctValues - should have 3 values
+    expect(resolvedTypeMetadata?.vctValues).toHaveLength(3);
+    expect(resolvedTypeMetadata?.vctValues[0]).toBe(
+      'http://example.com/middle',
+    );
+    expect(resolvedTypeMetadata?.vctValues[1]).toBe(
+      'http://example.com/extending',
+    );
+    expect(resolvedTypeMetadata?.vctValues[2]).toBe('http://example.com/base');
+  });
+
+  test('VCT with circular dependency should throw error', async () => {
+    const expectedPayload: SdJwtVcPayload = {
+      iat,
+      iss,
+      vct: 'http://example.com/circular',
+      ...claims,
+    };
+
+    const encodedSdjwt = await sdjwt.issue(
+      expectedPayload,
+      disclosureFrame as unknown as DisclosureFrame<SdJwtVcPayload>,
+    );
+
+    await expect(sdjwt.getVct(encodedSdjwt)).rejects.toThrowError(
+      'Circular dependency detected in VCT extends chain: http://example.com/circular',
+    );
+  });
+
+  test('VCT with max depth exceeded should throw error', async () => {
+    const sdjwtWithShallowDepth = new SDJwtVcInstance({
+      signer,
+      signAlg: 'EdDSA',
+      verifier,
+      hasher: digest,
+      hashAlg: 'sha-256',
+      saltGenerator: generateSalt,
+      loadTypeMetadataFormat: true,
+      timeout: 1000,
+      maxVctExtendsDepth: 1, // Only allow 1 level of extends
+    });
+
+    const expectedPayload: SdJwtVcPayload = {
+      iat,
+      iss,
+      vct: 'http://example.com/middle', // This has 2 levels of extends
+      ...claims,
+    };
+
+    const encodedSdjwt = await sdjwtWithShallowDepth.issue(
+      expectedPayload,
+      disclosureFrame as unknown as DisclosureFrame<SdJwtVcPayload>,
+    );
+
+    await expect(
+      sdjwtWithShallowDepth.getVct(encodedSdjwt),
+    ).rejects.toThrowError('Maximum VCT extends depth of 1 exceeded');
+  });
+
+  test('VCT extends chain should work in verify method', async () => {
+    const expectedPayload: SdJwtVcPayload = {
+      iat,
+      iss,
+      vct: 'http://example.com/extending',
+      ...claims,
+    };
+
+    const encodedSdjwt = await sdjwt.issue(
+      expectedPayload,
+      disclosureFrame as unknown as DisclosureFrame<SdJwtVcPayload>,
+    );
+
+    // Should not throw and should resolve the extends chain
+    const result = await sdjwt.verify(encodedSdjwt);
+    expect(result.payload.vct).toBe('http://example.com/extending');
+
+    // Check that typeMetadata was populated with resolved chain
+    expect(result.typeMetadata?.mergedTypeMetadata.claims).toHaveLength(2);
+    expect(result.typeMetadata?.typeMetadataChain).toHaveLength(2);
+    expect(result.typeMetadata?.vctValues).toHaveLength(2);
+  });
+
+  test('VCT with overriding claim metadata', async () => {
+    const expectedPayload: SdJwtVcPayload = {
+      iat,
+      iss,
+      vct: 'http://example.com/overriding',
+      ...claims,
+    };
+
+    const encodedSdjwt = await sdjwt.issue(
+      expectedPayload,
+      disclosureFrame as unknown as DisclosureFrame<SdJwtVcPayload>,
+    );
+
+    const resolvedTypeMetadata = await sdjwt.getVct(encodedSdjwt);
+
+    // Check mergedTypeMetadata - should have 2 claims: overridden firstName and new middleName
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims).toHaveLength(2);
+
+    // First claim should be the overridden firstName with new label and sd property
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims?.[0].path).toEqual([
+      'firstName',
+    ]);
+    expect(
+      resolvedTypeMetadata?.mergedTypeMetadata.claims?.[0].display?.[0].label,
+    ).toBe('Given Name');
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims?.[0].sd).toBe(
+      'always',
+    );
+
+    // Second claim should be the new middleName
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims?.[1].path).toEqual([
+      'middleName',
+    ]);
+    expect(
+      resolvedTypeMetadata?.mergedTypeMetadata.claims?.[1].display?.[0].label,
+    ).toBe('Middle Name');
+
+    // Check typeMetadataChain - should have 2 documents
+    expect(resolvedTypeMetadata?.typeMetadataChain).toHaveLength(2);
+    expect(resolvedTypeMetadata?.typeMetadataChain[0].vct).toBe(
+      'http://example.com/overriding',
+    );
+    expect(resolvedTypeMetadata?.typeMetadataChain[1].vct).toBe(
+      'http://example.com/base',
+    );
+
+    // Check vctValues
+    expect(resolvedTypeMetadata?.vctValues).toHaveLength(2);
+    expect(resolvedTypeMetadata?.vctValues[0]).toBe(
+      'http://example.com/overriding',
+    );
+    expect(resolvedTypeMetadata?.vctValues[1]).toBe('http://example.com/base');
+  });
+
+  test('VCT with valid sd property change (allowed to always)', async () => {
+    const expectedPayload: SdJwtVcPayload = {
+      iat,
+      iss,
+      vct: 'http://example.com/valid-sd-change',
+      ...claims,
+    };
+
+    const encodedSdjwt = await sdjwt.issue(
+      expectedPayload,
+      disclosureFrame as unknown as DisclosureFrame<SdJwtVcPayload>,
+    );
+
+    const resolvedTypeMetadata = await sdjwt.getVct(encodedSdjwt);
+
+    // Check mergedTypeMetadata - should successfully merge - changing from undefined/allowed to always is valid
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims).toHaveLength(1);
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims?.[0].path).toEqual([
+      'firstName',
+    ]);
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.claims?.[0].sd).toBe(
+      'always',
+    );
+
+    // Check typeMetadataChain
+    expect(resolvedTypeMetadata?.typeMetadataChain).toHaveLength(2);
+    expect(resolvedTypeMetadata?.vctValues).toHaveLength(2);
+  });
+
+  test('VCT with invalid sd property change (always to never) should throw error', async () => {
+    const expectedPayload: SdJwtVcPayload = {
+      iat,
+      iss,
+      vct: 'http://example.com/invalid-sd-change',
+      ...claims,
+    };
+
+    const encodedSdjwt = await sdjwt.issue(
+      expectedPayload,
+      disclosureFrame as unknown as DisclosureFrame<SdJwtVcPayload>,
+    );
+
+    await expect(sdjwt.getVct(encodedSdjwt)).rejects.toThrowError(
+      "Cannot change 'sd' property from 'always' to 'never' for claim at path [\"sensitiveData\"]",
+    );
+  });
+
+  test('VCT extending type without display should inherit base display', async () => {
+    const expectedPayload: SdJwtVcPayload = {
+      iat,
+      iss,
+      vct: 'http://example.com/middle', // middle doesn't define display
+      ...claims,
+    };
+
+    const encodedSdjwt = await sdjwt.issue(
+      expectedPayload,
+      disclosureFrame as unknown as DisclosureFrame<SdJwtVcPayload>,
+    );
+
+    const resolvedTypeMetadata = await sdjwt.getVct(encodedSdjwt);
+
+    // Check mergedTypeMetadata - since middle doesn't define display, it should inherit from extending which has display
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.display).toHaveLength(2);
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.display?.[0].lang).toBe(
+      'en',
+    );
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.display?.[1].lang).toBe(
+      'de',
+    );
+
+    // Check typeMetadataChain - should have 3 documents
+    expect(resolvedTypeMetadata?.typeMetadataChain).toHaveLength(3);
+    expect(resolvedTypeMetadata?.vctValues).toHaveLength(3);
+  });
 });

--- a/packages/sd-jwt-vc/src/verification-result.ts
+++ b/packages/sd-jwt-vc/src/verification-result.ts
@@ -1,6 +1,6 @@
 import type { kbHeader, kbPayload } from '@sd-jwt/types';
 import type { SdJwtVcPayload } from './sd-jwt-vc-payload';
-import type { TypeMetadataFormat } from './sd-jwt-vc-type-metadata-format';
+import type { ResolvedTypeMetadata } from './sd-jwt-vc-type-metadata-format';
 
 export type VerificationResult = {
   payload: SdJwtVcPayload;
@@ -11,5 +11,6 @@ export type VerificationResult = {
         header: kbHeader;
       }
     | undefined;
-  typeMetadataFormat?: TypeMetadataFormat;
+
+  typeMetadata?: ResolvedTypeMetadata;
 };


### PR DESCRIPTION
This PR adds support for resolving and merging a type metadata chain by resolving each consecutive `extends` claim.

This is a breaking change since the structure is now an object, as it returns both the merged objects as the chain.

The chain is returned as post processing might be needed for extensions to the type metadata (e.g. the TS12 Payment defines extensions to the type metadata which may require custom merging logic).

A `maxVctExtendsDepth` with default 5 is added to prevent an excessively deep chain. This can be overridden.

I did not implement the merging and extends logic for `vctm`, as it's been removed from the spec. See also #346


Fixes #336 
