### PR TITLE
fix: missing/updated fields in type metadata

### DIFF
--- a/packages/sd-jwt-vc/src/sd-jwt-vc-type-metadata-format.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-type-metadata-format.ts
@@ -100,16 +100,35 @@ export type Rendering = z.infer<typeof RenderingSchema>;
 /**
  * Display metadata associated with a credential type.
  */
-export const DisplaySchema = z.looseObject({
-  /** REQUIRED. Language tag according to RFC 5646 (e.g., "en", "de"). */
-  lang: z.string(),
-  /** REQUIRED. Human-readable name for the credential type. */
-  name: z.string(),
-  /** OPTIONAL. Description of the credential type for end users. */
-  description: z.string().optional(),
-  /** OPTIONAL. Rendering information (simple or SVG) for the credential. */
-  rendering: RenderingSchema.optional(),
-});
+export const DisplaySchema = z
+  .looseObject({
+    /**
+     * Language tag according to RFC 5646 (e.g., "en", "de").
+     * @deprecated - use `locale` instead
+     */
+    lang: z.string().optional(),
+
+    /**
+     * REQUIRED (preferred). Language tag according to RFC 5646.
+     * Alias for `lang` - either `lang` or `locale` must be provided.
+     */
+    locale: z.string().optional(),
+
+    /** REQUIRED. Human-readable name for the credential type. */
+    name: z.string(),
+    /** OPTIONAL. Description of the credential type for end users. */
+    description: z.string().optional(),
+    /** OPTIONAL. Rendering information (simple or SVG) for the credential. */
+    rendering: RenderingSchema.optional(),
+  })
+  .transform(({ lang, locale, ...rest }) => ({
+    ...rest,
+    locale: locale ?? lang,
+  }))
+  .refine(({ locale }) => locale !== undefined, {
+    message:
+      'Either locale (preferred) or lang (spec name, deprecated) MUST be defined on claim display entry.',
+  });
 
 export type Display = z.infer<typeof DisplaySchema>;
 

--- a/packages/sd-jwt-vc/src/test/vct.spec.ts
+++ b/packages/sd-jwt-vc/src/test/vct.spec.ts
@@ -27,7 +27,7 @@ const baseVctm: TypeMetadataFormat = {
   ],
   display: [
     {
-      lang: 'en',
+      locale: 'en',
       name: 'Base Credential',
       description: 'Base description',
     },
@@ -47,12 +47,12 @@ const extendingVctm: TypeMetadataFormat = {
   ],
   display: [
     {
-      lang: 'en',
+      locale: 'en',
       name: 'Extended Credential',
       description: 'Extended description',
     },
     {
-      lang: 'de',
+      locale: 'de',
       name: 'Erweiterte Berechtigung',
       description: 'Erweiterte Beschreibung',
     },
@@ -368,12 +368,12 @@ describe('App', () => {
     // Display from extending type completely replaces base display (section 8.2)
     expect(resolvedTypeMetadata?.mergedTypeMetadata.display).toHaveLength(2);
     expect(resolvedTypeMetadata?.mergedTypeMetadata.display?.[0]).toEqual({
-      lang: 'en',
+      locale: 'en',
       name: 'Extended Credential',
       description: 'Extended description',
     });
     expect(resolvedTypeMetadata?.mergedTypeMetadata.display?.[1]).toEqual({
-      lang: 'de',
+      locale: 'de',
       name: 'Erweiterte Berechtigung',
       description: 'Erweiterte Beschreibung',
     });
@@ -650,10 +650,10 @@ describe('App', () => {
 
     // Check mergedTypeMetadata - since middle doesn't define display, it should inherit from extending which has display
     expect(resolvedTypeMetadata?.mergedTypeMetadata.display).toHaveLength(2);
-    expect(resolvedTypeMetadata?.mergedTypeMetadata.display?.[0].lang).toBe(
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.display?.[0].locale).toBe(
       'en',
     );
-    expect(resolvedTypeMetadata?.mergedTypeMetadata.display?.[1].lang).toBe(
+    expect(resolvedTypeMetadata?.mergedTypeMetadata.display?.[1].locale).toBe(
       'de',
     );
 


### PR DESCRIPTION
Found a few more fields that weren't fully updated with the latest draft yet.

- Added background image
- Updated `svg_template` to `svg_templates` (for now it marks the old syntax as deprecated and transforms to the new plural param)