### PR TITLE
Fix/228

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -41,3 +41,68 @@ If you want to use the pure sd-jwt class or implement your own sd-jwt credential
 - @sd-jwt/present
 - @sd-jwt/types
 - @sd-jwt/utils
+
+### Verification
+
+The library provides two verification approaches:
+
+#### Standard Verification (Fail-Fast)
+
+The `verify()` method throws an error immediately when the first validation failure is encountered:
+
+```typescript
+try {
+  const result = await sdjwt.verify(credential);
+  console.log('Verified payload:', result.payload);
+} catch (error) {
+  console.error('Verification failed:', error.message);
+}
+```
+
+#### Safe Verification (Collect All Errors)
+
+The `safeVerify()` method collects all validation errors instead of failing on the first one. This is useful when you want to show users all issues with a credential at once:
+
+```typescript
+import type { SafeVerifyResult, VerificationError } from '@sd-jwt/types';
+
+const result = await sdjwt.safeVerify(credential);
+
+if (result.success) {
+  // Verification succeeded
+  console.log('Verified payload:', result.data.payload);
+  console.log('Header:', result.data.header);
+  if (result.data.kb) {
+    console.log('Key binding:', result.data.kb);
+  }
+} else {
+  // Verification failed - inspect all errors
+  for (const error of result.errors) {
+    console.error(`[${error.code}] ${error.message}`);
+    if (error.details) {
+      console.error('Details:', error.details);
+    }
+  }
+}
+```
+
+##### Error Codes
+
+The `safeVerify()` method returns errors with the following codes:
+
+| Code | Description |
+|------|-------------|
+| `HASHER_NOT_FOUND` | Hasher function not configured |
+| `VERIFIER_NOT_FOUND` | Verifier function not configured |
+| `INVALID_SD_JWT` | SD-JWT structure is invalid or cannot be decoded |
+| `INVALID_JWT_FORMAT` | JWT format is malformed |
+| `JWT_NOT_YET_VALID` | JWT `iat` or `nbf` claim is in the future |
+| `JWT_EXPIRED` | JWT `exp` claim is in the past |
+| `INVALID_JWT_SIGNATURE` | Signature verification failed |
+| `MISSING_REQUIRED_CLAIMS` | Required claim keys are not present |
+| `KEY_BINDING_JWT_MISSING` | Key binding JWT required but not present |
+| `KEY_BINDING_VERIFIER_NOT_FOUND` | Key binding verifier not configured |
+| `KEY_BINDING_SIGNATURE_INVALID` | Key binding signature verification failed |
+| `KEY_BINDING_SD_HASH_INVALID` | Key binding `sd_hash` does not match |
+| `UNKNOWN_ERROR` | An unexpected error occurred |
+

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -277,7 +277,10 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload> {
     SafeVerifyResult<{
       payload: ExtendedPayload;
       header: Record<string, unknown> | undefined;
-      kb?: { payload: Record<string, unknown>; header: Record<string, unknown> };
+      kb?: {
+        payload: Record<string, unknown>;
+        header: Record<string, unknown>;
+      };
     }>
   > {
     const errors: VerificationError[] = [];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -272,7 +272,7 @@ export class SDJwtInstance<ExtendedPayload extends SdJwtPayload, T = unknown> {
    */
   public async safeVerify(
     encodedSDJwt: string,
-    options?: VerifierOptions,
+    options?: T & VerifierOptions,
   ): Promise<
     SafeVerifyResult<{
       payload: ExtendedPayload;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,10 +7,10 @@ import {
   KB_JWT_TYP,
   type KBOptions,
   type PresentationFrame,
+  type SafeVerifyResult,
   type SDJWTCompact,
   type SDJWTConfig,
   type Signer,
-  type SafeVerifyResult,
   type VerificationError,
   type VerificationErrorCode,
 } from '@sd-jwt/types';

--- a/packages/core/src/test/index.spec.ts
+++ b/packages/core/src/test/index.spec.ts
@@ -627,4 +627,156 @@ describe('index', () => {
       expect(decode).toBeDefined();
     },
   );
+
+  test('safeVerify - success case', async () => {
+    const { signer, verifier } = createSignerVerifier();
+    const sdjwt = new SDJwtInstance<SdJwtPayload>({
+      signer,
+      signAlg: 'EdDSA',
+      verifier,
+      hasher: digest,
+      saltGenerator: generateSalt,
+    });
+
+    const credential = await sdjwt.issue(
+      {
+        foo: 'bar',
+        iss: 'Issuer',
+        iat: Math.floor(Date.now() / 1000),
+      },
+      {
+        _sd: ['foo'],
+      },
+    );
+
+    const result = await sdjwt.safeVerify(credential);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.payload).toBeDefined();
+      expect(result.data.payload.foo).toBe('bar');
+    }
+  });
+
+  test('safeVerify - collect multiple errors', async () => {
+    const sdjwt = new SDJwtInstance<SdJwtPayload>({});
+
+    const result = await sdjwt.safeVerify('invalid.jwt.token');
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Should have multiple errors: hasher not found, verifier not found
+      expect(result.errors.length).toBeGreaterThanOrEqual(2);
+      const errorCodes = result.errors.map((e) => e.code);
+      expect(errorCodes).toContain('HASHER_NOT_FOUND');
+      expect(errorCodes).toContain('VERIFIER_NOT_FOUND');
+    }
+  });
+
+  test('safeVerify - invalid signature error', async () => {
+    const { signer, verifier } = createSignerVerifier();
+    const { verifier: wrongVerifier } = createSignerVerifier(); // Different key pair
+
+    const issuer = new SDJwtInstance<SdJwtPayload>({
+      signer,
+      signAlg: 'EdDSA',
+      hasher: digest,
+      saltGenerator: generateSalt,
+    });
+
+    const verifierInstance = new SDJwtInstance<SdJwtPayload>({
+      verifier: wrongVerifier,
+      hasher: digest,
+    });
+
+    const credential = await issuer.issue(
+      {
+        foo: 'bar',
+        iss: 'Issuer',
+        iat: Math.floor(Date.now() / 1000),
+      },
+      {
+        _sd: ['foo'],
+      },
+    );
+
+    const result = await verifierInstance.safeVerify(credential);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // The error message from the verifier contains 'signature' which maps to INVALID_JWT_SIGNATURE
+      const hasSignatureError = result.errors.some(
+        (e) =>
+          e.code === 'INVALID_JWT_SIGNATURE' ||
+          e.message.toLowerCase().includes('signature'),
+      );
+      expect(hasSignatureError).toBe(true);
+    }
+  });
+
+  test('safeVerify - expired JWT error', async () => {
+    const { signer, verifier } = createSignerVerifier();
+    const sdjwt = new SDJwtInstance<SdJwtPayload>({
+      signer,
+      signAlg: 'EdDSA',
+      verifier,
+      hasher: digest,
+      saltGenerator: generateSalt,
+    });
+
+    const credential = await sdjwt.issue(
+      {
+        foo: 'bar',
+        iss: 'Issuer',
+        iat: Math.floor(Date.now() / 1000) - 3600, // 1 hour ago
+        exp: Math.floor(Date.now() / 1000) - 1800, // Expired 30 min ago
+      },
+      {
+        _sd: ['foo'],
+      },
+    );
+
+    const result = await sdjwt.safeVerify(credential);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors.some((e) => e.code === 'JWT_EXPIRED')).toBe(true);
+    }
+  });
+
+  test('safeVerify - missing required claims error', async () => {
+    const { signer, verifier } = createSignerVerifier();
+    const sdjwt = new SDJwtInstance<SdJwtPayload>({
+      signer,
+      signAlg: 'EdDSA',
+      verifier,
+      hasher: digest,
+      saltGenerator: generateSalt,
+    });
+
+    const credential = await sdjwt.issue(
+      {
+        foo: 'bar',
+        iss: 'Issuer',
+        iat: Math.floor(Date.now() / 1000),
+      },
+      {
+        _sd: ['foo'],
+      },
+    );
+
+    // Present without disclosing 'foo'
+    const presentation = await sdjwt.present(credential, {});
+
+    const result = await sdjwt.safeVerify(presentation, {
+      requiredClaimKeys: ['foo', 'missing_claim'],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.errors.some((e) => e.code === 'MISSING_REQUIRED_CLAIMS'),
+      ).toBe(true);
+    }
+  });
 });

--- a/packages/core/src/test/index.spec.ts
+++ b/packages/core/src/test/index.spec.ts
@@ -674,7 +674,7 @@ describe('index', () => {
   });
 
   test('safeVerify - invalid signature error', async () => {
-    const { signer, verifier } = createSignerVerifier();
+    const { signer } = createSignerVerifier();
     const { verifier: wrongVerifier } = createSignerVerifier(); // Different key pair
 
     const issuer = new SDJwtInstance<SdJwtPayload>({

--- a/packages/sd-jwt-vc/README.md
+++ b/packages/sd-jwt-vc/README.md
@@ -109,6 +109,63 @@ The library will load load the type metadata format based on the `vct` value acc
 
 Since at this point the display is not yet implemented, the library will only validate the schema and return the type metadata format. In the future the values of the type metadata can be fetched via a function call.
 
+### Verification
+
+The library provides two verification approaches:
+
+#### Standard Verification (Fail-Fast)
+
+The `verify()` method throws an error immediately when the first validation failure is encountered:
+
+```typescript
+try {
+  const result = await sdjwt.verify(presentation);
+  console.log('Verified payload:', result.payload);
+} catch (error) {
+  console.error('Verification failed:', error.message);
+}
+```
+
+#### Safe Verification (Collect All Errors)
+
+The `safeVerify()` method collects all validation errors instead of failing on the first one. This is useful when you want to show users all issues with a credential at once, including signature, status (revocation), and VCT metadata validation:
+
+```typescript
+import type { SafeVerifyResult, VerificationError } from '@sd-jwt/types';
+
+const result = await sdjwt.safeVerify(presentation);
+
+if (result.success) {
+  // Verification succeeded
+  console.log('Verified payload:', result.payload);
+  console.log('Header:', result.header);
+  if (result.kb) {
+    console.log('Key binding:', result.kb);
+  }
+  if (result.typeMetadata) {
+    console.log('Type metadata:', result.typeMetadata);
+  }
+} else {
+  // Verification failed - inspect all errors
+  for (const error of result.errors) {
+    console.error(`[${error.code}] ${error.message}`);
+    if (error.details) {
+      console.error('Details:', error.details);
+    }
+  }
+}
+```
+
+##### SD-JWT-VC Specific Error Codes
+
+In addition to the [core error codes](../core/README.md#error-codes), `safeVerify()` in SD-JWT-VC can return:
+
+| Code | Description |
+|------|-------------|
+| `STATUS_VERIFICATION_FAILED` | Status list fetch or verification failed |
+| `STATUS_INVALID` | Credential status indicates revocation |
+| `VCT_VERIFICATION_FAILED` | VCT type metadata fetch or validation failed |
+
 ### Dependencies
 
 - @sd-jwt/core

--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -178,7 +178,7 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
       result = {
         payload: baseResult.data.payload as SdJwtVcPayload,
         header: baseResult.data.header,
-        kb: baseResult.data.kb,
+        kb: baseResult.data.kb as VerificationResult['kb'],
       };
     } else {
       // Try to extract payload even if verification failed for status/vct checks

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -34,6 +34,27 @@ Ensure you have Node.js installed as a prerequisite.
 
 Check out more details in our [documentation](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/docs) or [examples](https://github.com/openwallet-foundation/sd-jwt-js/tree/main/examples)
 
+### Verification Types
+
+The package exports types for safe verification that collects all errors:
+
+```typescript
+import type {
+  SafeVerifyResult,
+  VerificationError,
+  VerificationErrorCode,
+} from '@sd-jwt/types';
+
+// SafeVerifyResult<T> is a discriminated union:
+// - { success: true; data: T } on success
+// - { success: false; errors: VerificationError[] } on failure
+
+// VerificationError contains:
+// - code: VerificationErrorCode (e.g., 'INVALID_JWT_SIGNATURE')
+// - message: string
+// - details?: unknown
+```
+
 ### Dependencies
 
 None

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,2 @@
 export * from './type';
+export * from './verification-error';

--- a/packages/types/src/verification-error.ts
+++ b/packages/types/src/verification-error.ts
@@ -1,0 +1,55 @@
+/**
+ * Error codes for SD-JWT verification errors.
+ */
+export type VerificationErrorCode =
+  | 'HASHER_NOT_FOUND'
+  | 'VERIFIER_NOT_FOUND'
+  | 'INVALID_SD_JWT'
+  | 'INVALID_JWT_FORMAT'
+  | 'JWT_NOT_YET_VALID'
+  | 'JWT_EXPIRED'
+  | 'INVALID_JWT_SIGNATURE'
+  | 'MISSING_REQUIRED_CLAIMS'
+  | 'KEY_BINDING_JWT_MISSING'
+  | 'KEY_BINDING_VERIFIER_NOT_FOUND'
+  | 'KEY_BINDING_SIGNATURE_INVALID'
+  | 'KEY_BINDING_SD_HASH_INVALID'
+  | 'STATUS_VERIFICATION_FAILED'
+  | 'STATUS_INVALID'
+  | 'VCT_VERIFICATION_FAILED'
+  | 'UNKNOWN_ERROR';
+
+/**
+ * Represents a single verification error.
+ */
+export type VerificationError = {
+  /**
+   * The error code identifying the type of error.
+   */
+  code: VerificationErrorCode;
+
+  /**
+   * Human-readable error message.
+   */
+  message: string;
+
+  /**
+   * Optional additional details about the error.
+   */
+  details?: unknown;
+};
+
+/**
+ * Result type for safe verification that collects all errors.
+ */
+export type SafeVerifyResult<T> =
+  | {
+      success: true;
+      data: T;
+      errors?: never;
+    }
+  | {
+      success: false;
+      data?: never;
+      errors: VerificationError[];
+    };


### PR DESCRIPTION
closes #228

adds safeverify that will run the checks in sequence without aborting at the first fail.

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>