### PR TITLE
feat: allow status list to be issued as cwt

### DIFF
--- a/packages/jwt-status-list/README.md
+++ b/packages/jwt-status-list/README.md
@@ -7,8 +7,8 @@
 
 ## jwt-status-list
 
-An implementation of the [Token Status List](https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/) for a JWT representation, not for CBOR.
-This library helps to verify the status of a specific entry in a JWT, and to generate a status list and pack it into a signed JWT. It does not provide any functions to manage the status list itself.
+An implementation of the [Token Status List](https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/) for both JWT and CWT (CBOR) representations.
+This library helps to verify the status of a specific entry in a JWT or CWT, and to generate a status list and pack it into a signed token. It does not provide any functions to manage the status list itself.
 
 ## Installation
 
@@ -28,6 +28,8 @@ pnpm install @sd-jwt/jwt-status-list
 Ensure you have Node.js installed as a prerequisite.
 
 ## Usage
+
+### JWT Status List
 
 Creation of a JWT Status List:
 
@@ -73,6 +75,215 @@ const statusList = getListFromStatusListJWT(list);
 const status = statusList.getStatus(reference.idx);
 ```
 
+### CWT Status List (CBOR)
+
+The library also supports CWT (CBOR Web Token) format as specified in [draft-ietf-oauth-status-list](https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html).
+
+Creation of a CWT Status List payload:
+
+```typescript
+import {
+  StatusList,
+  createStatusListCWTPayload,
+  createStatusListCWTHeader,
+  encodeCWTPayload,
+  COSEAlgorithms,
+} from '@sd-jwt/jwt-status-list';
+
+// Create the status list
+const list = new StatusList([1, 0, 1, 1, 1], 1);
+const subject = 'https://example.com/statuslists/1';
+const issuedAt = Math.floor(Date.now() / 1000);
+
+// Create CWT payload with numeric claim keys per spec
+const payload = createStatusListCWTPayload(list, subject, issuedAt, {
+  exp: issuedAt + 86400, // optional: expiration in 1 day
+  ttl: 43200, // optional: time to live in seconds
+});
+
+// Create CWT header (simple form with just kid)
+const header = createStatusListCWTHeader(COSEAlgorithms.ES256, 'key-id-1');
+
+// Create CWT header with X.509 key resolution options
+const headerWithX509 = createStatusListCWTHeader(COSEAlgorithms.ES256, {
+  kid: 'key-id-1',
+  x5chain: certificateChain, // X.509 certificate chain
+  x5t: certificateThumbprint, // SHA-256 thumbprint
+  x5u: 'https://example.com/certs', // URL to certificates
+});
+
+// Encode to CBOR (for use in COSE_Sign1 or COSE_Mac0)
+const cborPayload = encodeCWTPayload(list, subject, issuedAt, {
+  exp: issuedAt + 86400,
+  ttl: 43200,
+});
+
+// The COSE signing is not provided by this library.
+// Use a COSE library like 'cose-js' to create the signed CWT.
+```
+
+Interaction with a CWT status list:
+
+```typescript
+import {
+  getListFromStatusListCWT,
+  getStatusListFromCWT,
+  decodeCWTPayload,
+} from '@sd-jwt/jwt-status-list';
+
+// CWT payload validation is not provided by this library!!!
+
+// Extract status list from CWT payload (CBOR bytes)
+const statusList = getListFromStatusListCWT(cwtPayloadBytes);
+
+// Get status of a specific entry
+const status = statusList.getStatus(idx);
+
+// Or decode the full CWT payload
+const decoded = decodeCWTPayload(cwtPayloadBytes);
+console.log(decoded.subject);
+console.log(decoded.issuedAt);
+console.log(decoded.statusList.getStatus(0));
+```
+
+For referenced tokens with status claims:
+
+```typescript
+import {
+  createCWTStatusClaim,
+  encodeCWTStatusClaim,
+  getStatusListFromCWT,
+} from '@sd-jwt/jwt-status-list';
+
+// Create a status claim for a referenced token
+const statusClaim = createCWTStatusClaim(0, 'https://example.com/statuslists/1');
+
+// Or encode it directly to CBOR
+const encodedClaim = encodeCWTStatusClaim(0, 'https://example.com/statuslists/1');
+
+// Extract status list reference from a referenced token CWT
+const reference = getStatusListFromCWT(referencedTokenPayload);
+console.log(reference.idx, reference.uri);
+```
+
+#### CWT Claim Keys
+
+The CWT format uses numeric claim keys as defined in the spec:
+
+| Claim | Key | Description |
+|-------|-----|-------------|
+| sub | 2 | Subject (URI of the Status List Token) |
+| exp | 4 | Expiration time |
+| iat | 6 | Issued at time |
+| ttl | 65534 | Time to live (seconds) |
+| status_list | 65533 | Status list data |
+| status | 65535 | Status claim (for referenced tokens) |
+
+#### COSE Algorithm Constants
+
+The library exports common COSE algorithm identifiers:
+
+```typescript
+import { COSEAlgorithms } from '@sd-jwt/jwt-status-list';
+
+COSEAlgorithms.ES256;  // -7
+COSEAlgorithms.ES384;  // -35
+COSEAlgorithms.ES512;  // -36
+COSEAlgorithms.EdDSA;  // -8
+COSEAlgorithms.PS256;  // -37
+COSEAlgorithms.RS256;  // -257
+```
+
+### Constants and Type Definitions
+
+The library exports various constants for easier reference when building applications.
+
+#### Status Types
+
+Status type values as defined in Section 7 of the spec:
+
+```typescript
+import { StatusTypes } from '@sd-jwt/jwt-status-list';
+
+StatusTypes.VALID;       // 0x00 - Token is valid
+StatusTypes.INVALID;     // 0x01 - Token is revoked/invalid
+StatusTypes.SUSPENDED;   // 0x02 - Token is temporarily suspended
+
+// Application-specific values
+StatusTypes.APPLICATION_SPECIFIC_3;           // 0x03
+StatusTypes.APPLICATION_SPECIFIC_RANGE_START; // 0x0C
+StatusTypes.APPLICATION_SPECIFIC_RANGE_END;   // 0x0F
+
+// Example: Check if a token is valid
+const status = statusList.getStatus(idx);
+if (status === StatusTypes.VALID) {
+  console.log('Token is valid');
+} else if (status === StatusTypes.INVALID) {
+  console.log('Token has been revoked');
+} else if (status === StatusTypes.SUSPENDED) {
+  console.log('Token is temporarily suspended');
+}
+```
+
+#### Media Types
+
+Media types for HTTP content negotiation:
+
+```typescript
+import { MediaTypes } from '@sd-jwt/jwt-status-list';
+
+MediaTypes.STATUS_LIST_JWT;  // 'application/statuslist+jwt'
+MediaTypes.STATUS_LIST_CWT;  // 'application/statuslist+cwt'
+
+// Example: Fetch status list with correct Accept header
+const response = await fetch(uri, {
+  headers: {
+    'Accept': MediaTypes.STATUS_LIST_JWT
+  }
+});
+```
+
+#### JWT Constants
+
+```typescript
+import { JWT_STATUS_LIST_TYPE, JWTClaimNames } from '@sd-jwt/jwt-status-list';
+
+JWT_STATUS_LIST_TYPE;  // 'statuslist+jwt' - for the typ header
+
+JWTClaimNames.STATUS;           // 'status'
+JWTClaimNames.STATUS_LIST;      // 'status_list'
+JWTClaimNames.TTL;              // 'ttl'
+JWTClaimNames.IDX;              // 'idx'
+JWTClaimNames.URI;              // 'uri'
+JWTClaimNames.BITS;             // 'bits'
+JWTClaimNames.LST;              // 'lst'
+JWTClaimNames.AGGREGATION_URI;  // 'aggregation_uri'
+```
+
+#### CWT Constants
+
+```typescript
+import { CWT_STATUS_LIST_TYPE, CWTClaimKeys, COSEHeaderKeys } from '@sd-jwt/jwt-status-list';
+
+CWT_STATUS_LIST_TYPE;  // 'application/statuslist+cwt' - for COSE type header
+
+// CWT claim keys (numeric)
+CWTClaimKeys.SUB;          // 2
+CWTClaimKeys.EXP;          // 4
+CWTClaimKeys.IAT;          // 6
+CWTClaimKeys.TTL;          // 65534
+CWTClaimKeys.STATUS_LIST;  // 65533
+CWTClaimKeys.STATUS;       // 65535
+
+// COSE header keys
+COSEHeaderKeys.ALG;       // 1
+COSEHeaderKeys.KID;       // 4
+COSEHeaderKeys.TYPE;      // 16
+COSEHeaderKeys.X5CHAIN;   // 33 - X.509 certificate chain
+COSEHeaderKeys.X5T;       // 34 - X.509 SHA-256 thumbprint
+COSEHeaderKeys.X5U;       // 35 - X.509 URL
+```
+
 ### Integration into sd-jwt-vc
 
 The status list can be integrated into the [sd-jwt-vc](../sd-jwt-vc/README.md) library to provide a way to verify the status of a credential. In the [test folder](../sd-jwt-vc/src/test/index.spec.ts) you will find an example how to add the status reference to a credential and also how to verify the status of a credential.
@@ -94,3 +305,4 @@ Run the tests:
 ```bash
 pnpm test
 ```
+

--- a/packages/jwt-status-list/package.json
+++ b/packages/jwt-status-list/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@sd-jwt/types": "workspace:*",
     "@sd-jwt/utils": "workspace:*",
+    "cbor-x": "^1.6.0",
     "pako": "^2.1.0"
   },
   "publishConfig": {

--- a/packages/jwt-status-list/src/index.ts
+++ b/packages/jwt-status-list/src/index.ts
@@ -1,4 +1,5 @@
 export * from './status-list';
+export * from './status-list-cwt';
 export * from './status-list-exception';
 export * from './status-list-jwt';
 export * from './types';

--- a/packages/jwt-status-list/src/status-list-cwt.ts
+++ b/packages/jwt-status-list/src/status-list-cwt.ts
@@ -1,0 +1,434 @@
+import * as cbor from 'cbor-x';
+import { StatusList } from './status-list';
+import { SLException } from './status-list-exception';
+import type {
+  BitsPerStatus,
+  CWTwithStatusListPayload,
+  StatusListCBOR,
+  StatusListCWTHeader,
+  StatusListCWTPayload,
+  StatusListEntry,
+} from './types';
+import {
+  CWT_STATUS_LIST_TYPE,
+  CWTStatusListInfoKeys,
+  CWTStatusListKeys,
+} from './types';
+
+/**
+ * CBOR-encodes a map with proper key ordering.
+ * According to CBOR canonical encoding, map keys should be ordered.
+ */
+function encodeCBORMap(obj: Record<string | number, unknown>): Uint8Array {
+  return cbor.encode(obj);
+}
+
+/**
+ * Decodes a CBOR byte array into an object.
+ */
+function decodeCBOR<T>(data: Uint8Array): T {
+  return cbor.decode(data) as T;
+}
+
+/**
+ * Creates the CWT claims payload for a Status List Token.
+ * @param list The StatusList instance
+ * @param subject The subject URI (must match the uri in the Referenced Token's status_list claim)
+ * @param issuedAt Unix timestamp when the token was issued
+ * @param options Optional parameters (exp, ttl, aggregationUri)
+ * @returns The CWT payload object with numeric keys
+ */
+export function createStatusListCWTPayload(
+  list: StatusList,
+  subject: string,
+  issuedAt: number,
+  options?: {
+    exp?: number;
+    ttl?: number;
+    aggregationUri?: string;
+  },
+): StatusListCWTPayload {
+  if (!subject) {
+    throw new SLException('subject is required');
+  }
+  if (!issuedAt) {
+    throw new SLException('issuedAt is required');
+  }
+
+  const statusListCBOR: StatusListCBOR = {
+    bits: list.getBitsPerStatus(),
+    lst: list.compressStatusListToBytes(),
+  };
+
+  if (options?.aggregationUri) {
+    statusListCBOR.aggregation_uri = options.aggregationUri;
+  }
+
+  // Use the numeric keys as defined in the spec
+  const payload: StatusListCWTPayload = {
+    2: subject, // sub
+    6: issuedAt, // iat
+    65533: statusListCBOR, // status_list
+  };
+
+  if (options?.exp !== undefined) {
+    payload[4] = options.exp; // exp
+  }
+
+  if (options?.ttl !== undefined) {
+    payload[65534] = options.ttl; // ttl
+  }
+
+  return payload;
+}
+
+/**
+ * Key resolution options for CWT header
+ */
+export interface CWTHeaderKeyOptions {
+  kid?: string | Uint8Array;
+  x5chain?: Uint8Array | Uint8Array[];
+  x5t?: Uint8Array;
+  x5u?: string;
+}
+
+/**
+ * Creates the protected header for a Status List CWT.
+ * @param alg COSE algorithm number (e.g., -7 for ES256, -35 for ES384, -36 for ES512)
+ * @param kidOrOptions Optional key identifier (string/Uint8Array) OR an options object for key resolution
+ * @returns The COSE protected header object with numeric keys
+ */
+export function createStatusListCWTHeader(
+  alg: number,
+  kidOrOptions?: string | Uint8Array | CWTHeaderKeyOptions,
+): StatusListCWTHeader {
+  const header: StatusListCWTHeader = {
+    1: alg, // alg
+    16: CWT_STATUS_LIST_TYPE, // type
+  };
+
+  // Handle backward compatible signature (kid as second arg)
+  if (kidOrOptions !== undefined) {
+    if (
+      typeof kidOrOptions === 'string' ||
+      kidOrOptions instanceof Uint8Array
+    ) {
+      header[4] = kidOrOptions; // kid
+    } else {
+      // New options object style
+      if (kidOrOptions.kid !== undefined) {
+        header[4] = kidOrOptions.kid; // kid
+      }
+
+      if (kidOrOptions.x5chain !== undefined) {
+        header[33] = kidOrOptions.x5chain; // x5chain
+      }
+
+      if (kidOrOptions.x5t !== undefined) {
+        header[34] = kidOrOptions.x5t; // x5t
+      }
+
+      if (kidOrOptions.x5u !== undefined) {
+        header[35] = kidOrOptions.x5u; // x5u
+      }
+    }
+  }
+
+  return header;
+}
+
+/**
+ * Encodes a Status List into CBOR format for CWT.
+ * Returns the CBOR-encoded status_list map.
+ * @param list The StatusList instance
+ * @param aggregationUri Optional aggregation URI
+ * @returns CBOR-encoded status_list
+ */
+export function encodeStatusListToCBOR(
+  list: StatusList,
+  aggregationUri?: string,
+): Uint8Array {
+  const statusListMap: Record<string, unknown> = {
+    [CWTStatusListKeys.BITS]: list.getBitsPerStatus(),
+    [CWTStatusListKeys.LST]: list.compressStatusListToBytes(),
+  };
+
+  if (aggregationUri) {
+    statusListMap[CWTStatusListKeys.AGGREGATION_URI] = aggregationUri;
+  }
+
+  return encodeCBORMap(statusListMap);
+}
+
+/**
+ * Decodes a CBOR-encoded status list.
+ * @param cborData CBOR-encoded status_list
+ * @returns StatusList instance
+ */
+export function decodeStatusListFromCBOR(cborData: Uint8Array): StatusList {
+  const decoded = decodeCBOR<StatusListCBOR>(cborData);
+  return StatusList.decompressStatusListFromBytes(decoded.lst, decoded.bits);
+}
+
+/**
+ * Encodes the full CWT claims payload to CBOR.
+ * This creates the unprotected payload that would be included in a COSE_Sign1 or COSE_Mac0 structure.
+ * @param list The StatusList instance
+ * @param subject The subject URI
+ * @param issuedAt Unix timestamp
+ * @param options Optional exp, ttl, aggregationUri
+ * @returns CBOR-encoded CWT claims
+ */
+export function encodeCWTPayload(
+  list: StatusList,
+  subject: string,
+  issuedAt: number,
+  options?: {
+    exp?: number;
+    ttl?: number;
+    aggregationUri?: string;
+  },
+): Uint8Array {
+  const payload = createStatusListCWTPayload(list, subject, issuedAt, options);
+
+  // Convert the payload to a CBOR-friendly format
+  // The status_list needs special handling for the internal structure
+  const cborPayload = new Map<number, unknown>();
+  cborPayload.set(2, payload[2]); // sub
+  cborPayload.set(6, payload[6]); // iat
+
+  if (payload[4] !== undefined) {
+    cborPayload.set(4, payload[4]); // exp
+  }
+  if (payload[65534] !== undefined) {
+    cborPayload.set(65534, payload[65534]); // ttl
+  }
+
+  // Encode status_list as a map with string keys
+  const statusListMap = new Map<string, unknown>();
+  statusListMap.set('bits', payload[65533].bits);
+  statusListMap.set('lst', payload[65533].lst);
+  if (payload[65533].aggregation_uri) {
+    statusListMap.set('aggregation_uri', payload[65533].aggregation_uri);
+  }
+  cborPayload.set(65533, statusListMap);
+
+  return cbor.encode(cborPayload);
+}
+
+/**
+ * Decodes a CBOR-encoded CWT payload.
+ * @param cborData CBOR-encoded CWT payload
+ * @returns Decoded payload with status list
+ */
+export function decodeCWTPayload(cborData: Uint8Array): {
+  subject: string;
+  issuedAt: number;
+  exp?: number;
+  ttl?: number;
+  statusList: StatusList;
+  aggregationUri?: string;
+} {
+  const decoded = decodeCBOR<Map<number, unknown>>(cborData);
+
+  // Handle both Map and plain object representations
+  const getValue = (key: number): unknown => {
+    if (decoded instanceof Map) {
+      return decoded.get(key);
+    }
+    return (decoded as Record<number, unknown>)[key];
+  };
+
+  const subject = getValue(2) as string;
+  const issuedAt = getValue(6) as number;
+  const exp = getValue(4) as number | undefined;
+  const ttl = getValue(65534) as number | undefined;
+  const statusListData = getValue(65533) as
+    | Map<string, unknown>
+    | Record<string, unknown>;
+
+  // Handle both Map and plain object for status_list
+  let bits: BitsPerStatus;
+  let lst: Uint8Array;
+  let aggregationUri: string | undefined;
+
+  if (statusListData instanceof Map) {
+    bits = statusListData.get('bits') as BitsPerStatus;
+    lst = statusListData.get('lst') as Uint8Array;
+    aggregationUri = statusListData.get('aggregation_uri') as
+      | string
+      | undefined;
+  } else {
+    bits = statusListData.bits as BitsPerStatus;
+    lst = statusListData.lst as Uint8Array;
+    aggregationUri = statusListData.aggregation_uri as string | undefined;
+  }
+
+  const statusList = StatusList.decompressStatusListFromBytes(lst, bits);
+
+  return {
+    subject,
+    issuedAt,
+    exp,
+    ttl,
+    statusList,
+    aggregationUri,
+  };
+}
+
+/**
+ * Creates a status claim for a Referenced Token in CWT format.
+ * This creates the status map that should be included in a CWT that references a status list.
+ * @param idx The index in the status list
+ * @param uri The URI of the Status List Token
+ * @returns The status structure suitable for CBOR encoding
+ */
+export function createCWTStatusClaim(
+  idx: number,
+  uri: string,
+): CWTwithStatusListPayload[65535] {
+  return {
+    status_list: {
+      idx,
+      uri,
+    },
+  };
+}
+
+/**
+ * Encodes a status claim for a Referenced Token to CBOR.
+ * @param idx The index in the status list
+ * @param uri The URI of the Status List Token
+ * @returns CBOR-encoded status claim
+ */
+export function encodeCWTStatusClaim(idx: number, uri: string): Uint8Array {
+  const statusClaim = new Map<string, unknown>();
+  const statusListInfo = new Map<string, unknown>();
+  statusListInfo.set(CWTStatusListInfoKeys.IDX, idx);
+  statusListInfo.set(CWTStatusListInfoKeys.URI, uri);
+  statusClaim.set('status_list', statusListInfo);
+
+  return cbor.encode(statusClaim);
+}
+
+/**
+ * Decodes a status claim from a Referenced Token CWT.
+ * @param cborData CBOR-encoded status claim
+ * @returns The StatusListEntry with idx and uri
+ */
+export function decodeCWTStatusClaim(cborData: Uint8Array): StatusListEntry {
+  const decoded = decodeCBOR<Map<string, unknown> | Record<string, unknown>>(
+    cborData,
+  );
+
+  let statusList: Map<string, unknown> | Record<string, unknown>;
+
+  if (decoded instanceof Map) {
+    statusList = decoded.get('status_list') as
+      | Map<string, unknown>
+      | Record<string, unknown>;
+  } else {
+    statusList = decoded.status_list as
+      | Map<string, unknown>
+      | Record<string, unknown>;
+  }
+
+  if (statusList instanceof Map) {
+    return {
+      idx: statusList.get(CWTStatusListInfoKeys.IDX) as number,
+      uri: statusList.get(CWTStatusListInfoKeys.URI) as string,
+    };
+  }
+  return {
+    idx: statusList[CWTStatusListInfoKeys.IDX] as number,
+    uri: statusList[CWTStatusListInfoKeys.URI] as string,
+  };
+}
+
+/**
+ * Extracts the status list from a decoded CWT payload without verifying the signature.
+ * This is similar to getListFromStatusListJWT but for CWT format.
+ * @param cwtPayload CBOR-encoded CWT payload (the claims portion)
+ * @returns StatusList instance
+ */
+export function getListFromStatusListCWT(cwtPayload: Uint8Array): StatusList {
+  const { statusList } = decodeCWTPayload(cwtPayload);
+  return statusList;
+}
+
+/**
+ * Extracts the status list entry from a decoded Referenced Token CWT.
+ * This is similar to getStatusListFromJWT but for CWT format.
+ * @param cwtPayload CBOR-encoded CWT payload containing the status claim
+ * @returns StatusListEntry with idx and uri
+ */
+export function getStatusListFromCWT(cwtPayload: Uint8Array): StatusListEntry {
+  const decoded = decodeCBOR<Map<number, unknown> | Record<number, unknown>>(
+    cwtPayload,
+  );
+
+  // Get the status claim (key 65535)
+  let statusClaim: Map<string, unknown> | Record<string, unknown>;
+
+  if (decoded instanceof Map) {
+    statusClaim = decoded.get(65535) as
+      | Map<string, unknown>
+      | Record<string, unknown>;
+  } else {
+    statusClaim = decoded[65535] as
+      | Map<string, unknown>
+      | Record<string, unknown>;
+  }
+
+  if (!statusClaim) {
+    throw new SLException('No status claim found in CWT payload');
+  }
+
+  let statusList: Map<string, unknown> | Record<string, unknown>;
+
+  if (statusClaim instanceof Map) {
+    statusList = statusClaim.get('status_list') as
+      | Map<string, unknown>
+      | Record<string, unknown>;
+  } else {
+    statusList = statusClaim.status_list as
+      | Map<string, unknown>
+      | Record<string, unknown>;
+  }
+
+  if (!statusList) {
+    throw new SLException('No status_list found in status claim');
+  }
+
+  if (statusList instanceof Map) {
+    return {
+      idx: statusList.get('idx') as number,
+      uri: statusList.get('uri') as string,
+    };
+  }
+
+  return {
+    idx: statusList.idx as number,
+    uri: statusList.uri as string,
+  };
+}
+
+/**
+ * COSE Algorithm identifiers commonly used
+ * @see https://www.iana.org/assignments/cose/cose.xhtml#algorithms
+ */
+export const COSEAlgorithms = {
+  ES256: -7,
+  ES384: -35,
+  ES512: -36,
+  EdDSA: -8,
+  PS256: -37,
+  PS384: -38,
+  PS512: -39,
+  RS256: -257,
+  RS384: -258,
+  RS512: -259,
+} as const;
+
+export type COSEAlgorithm =
+  (typeof COSEAlgorithms)[keyof typeof COSEAlgorithms];

--- a/packages/jwt-status-list/src/status-list-jwt.ts
+++ b/packages/jwt-status-list/src/status-list-jwt.ts
@@ -8,6 +8,7 @@ import type {
   StatusListJWTHeaderParameters,
   StatusListJWTPayload,
 } from './types';
+import { JWT_STATUS_LIST_TYPE } from './types';
 
 /**
  * Decode a JWT and return the payload.
@@ -40,7 +41,7 @@ export function createHeaderAndPayload(
   }
   //exp and tll are optional. We will not validate the business logic of the values like exp > iat etc.
 
-  header.typ = 'statuslist+jwt';
+  header.typ = JWT_STATUS_LIST_TYPE;
   payload.status_list = {
     bits: list.getBitsPerStatus(),
     lst: list.compressStatusList(),

--- a/packages/jwt-status-list/src/test/status-list-cwt.spec.ts
+++ b/packages/jwt-status-list/src/test/status-list-cwt.spec.ts
@@ -1,0 +1,332 @@
+import * as cbor from 'cbor-x';
+import { describe, expect, it } from 'vitest';
+import { StatusList } from '../status-list';
+import {
+  COSEAlgorithms,
+  createCWTStatusClaim,
+  createStatusListCWTHeader,
+  createStatusListCWTPayload,
+  decodeCWTPayload,
+  decodeCWTStatusClaim,
+  decodeStatusListFromCBOR,
+  encodeCWTPayload,
+  encodeCWTStatusClaim,
+  encodeStatusListToCBOR,
+  getListFromStatusListCWT,
+  getStatusListFromCWT,
+} from '../status-list-cwt';
+import { COSEHeaderKeys, CWT_STATUS_LIST_TYPE, CWTClaimKeys } from '../types';
+
+describe('CWTStatusList', () => {
+  describe('createStatusListCWTPayload', () => {
+    it('should create a valid CWT payload with required fields', () => {
+      const statusList = new StatusList([1, 0, 1, 1, 0], 1);
+      const subject = 'https://example.com/statuslists/1';
+      const issuedAt = Math.floor(Date.now() / 1000);
+
+      const payload = createStatusListCWTPayload(statusList, subject, issuedAt);
+
+      expect(payload[CWTClaimKeys.SUB]).toBe(subject);
+      expect(payload[CWTClaimKeys.IAT]).toBe(issuedAt);
+      expect(payload[CWTClaimKeys.STATUS_LIST]).toBeDefined();
+      expect(payload[CWTClaimKeys.STATUS_LIST].bits).toBe(1);
+      expect(payload[CWTClaimKeys.STATUS_LIST].lst).toBeInstanceOf(Uint8Array);
+    });
+
+    it('should create a CWT payload with optional exp and ttl', () => {
+      const statusList = new StatusList([1, 0, 1, 1, 0], 1);
+      const subject = 'https://example.com/statuslists/1';
+      const issuedAt = Math.floor(Date.now() / 1000);
+      const exp = issuedAt + 86400; // 1 day
+      const ttl = 43200; // 12 hours
+
+      const payload = createStatusListCWTPayload(
+        statusList,
+        subject,
+        issuedAt,
+        {
+          exp,
+          ttl,
+        },
+      );
+
+      expect(payload[CWTClaimKeys.EXP]).toBe(exp);
+      expect(payload[CWTClaimKeys.TTL]).toBe(ttl);
+    });
+
+    it('should include aggregation_uri when provided', () => {
+      const statusList = new StatusList([1, 0, 1, 1, 0], 1);
+      const subject = 'https://example.com/statuslists/1';
+      const issuedAt = Math.floor(Date.now() / 1000);
+      const aggregationUri = 'https://example.com/status-aggregation';
+
+      const payload = createStatusListCWTPayload(
+        statusList,
+        subject,
+        issuedAt,
+        {
+          aggregationUri,
+        },
+      );
+
+      expect(payload[CWTClaimKeys.STATUS_LIST].aggregation_uri).toBe(
+        aggregationUri,
+      );
+    });
+
+    it('should throw error when subject is missing', () => {
+      const statusList = new StatusList([1, 0, 1, 1, 0], 1);
+      const issuedAt = Math.floor(Date.now() / 1000);
+
+      expect(() =>
+        createStatusListCWTPayload(statusList, '', issuedAt),
+      ).toThrow('subject is required');
+    });
+
+    it('should throw error when issuedAt is missing', () => {
+      const statusList = new StatusList([1, 0, 1, 1, 0], 1);
+      const subject = 'https://example.com/statuslists/1';
+
+      expect(() => createStatusListCWTPayload(statusList, subject, 0)).toThrow(
+        'issuedAt is required',
+      );
+    });
+  });
+
+  describe('createStatusListCWTHeader', () => {
+    it('should create a valid CWT header', () => {
+      const header = createStatusListCWTHeader(COSEAlgorithms.ES256);
+
+      expect(header[COSEHeaderKeys.ALG]).toBe(COSEAlgorithms.ES256);
+      expect(header[COSEHeaderKeys.TYPE]).toBe(CWT_STATUS_LIST_TYPE);
+    });
+
+    it('should include kid when provided as string', () => {
+      const header = createStatusListCWTHeader(COSEAlgorithms.ES256, '12');
+
+      expect(header[COSEHeaderKeys.KID]).toBe('12');
+    });
+
+    it('should include kid when provided as Uint8Array', () => {
+      const kidBytes = new Uint8Array([0x31, 0x32]); // "12"
+      const header = createStatusListCWTHeader(COSEAlgorithms.ES256, kidBytes);
+
+      expect(header[COSEHeaderKeys.KID]).toBe(kidBytes);
+    });
+
+    it('should include key resolution options when provided', () => {
+      const x5chain = new Uint8Array([0x01, 0x02, 0x03]);
+      const x5t = new Uint8Array([0x04, 0x05, 0x06]);
+      const x5u = 'https://example.com/certs';
+
+      const header = createStatusListCWTHeader(COSEAlgorithms.ES256, {
+        kid: 'key-1',
+        x5chain,
+        x5t,
+        x5u,
+      });
+
+      expect(header[COSEHeaderKeys.ALG]).toBe(COSEAlgorithms.ES256);
+      expect(header[COSEHeaderKeys.TYPE]).toBe(CWT_STATUS_LIST_TYPE);
+      expect(header[COSEHeaderKeys.KID]).toBe('key-1');
+      expect(header[33]).toBe(x5chain); // x5chain
+      expect(header[34]).toBe(x5t); // x5t
+      expect(header[35]).toBe(x5u); // x5u
+    });
+  });
+
+  describe('encodeStatusListToCBOR / decodeStatusListFromCBOR', () => {
+    it('should roundtrip encode and decode status list', () => {
+      const originalList = [1, 0, 1, 1, 0, 1, 0, 1];
+      const statusList = new StatusList(originalList, 1);
+
+      const encoded = encodeStatusListToCBOR(statusList);
+      const decoded = decodeStatusListFromCBOR(encoded);
+
+      for (let i = 0; i < originalList.length; i++) {
+        expect(decoded.getStatus(i)).toBe(originalList[i]);
+      }
+    });
+
+    it('should handle 2-bit status values', () => {
+      const originalList = [0, 1, 2, 3, 1, 2];
+      const statusList = new StatusList(originalList, 2);
+
+      const encoded = encodeStatusListToCBOR(statusList);
+      const decoded = decodeStatusListFromCBOR(encoded);
+
+      for (let i = 0; i < originalList.length; i++) {
+        expect(decoded.getStatus(i)).toBe(originalList[i]);
+      }
+    });
+
+    it('should handle 4-bit status values', () => {
+      const originalList = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15];
+      const statusList = new StatusList(originalList, 4);
+
+      const encoded = encodeStatusListToCBOR(statusList);
+      const decoded = decodeStatusListFromCBOR(encoded);
+
+      for (let i = 0; i < originalList.length; i++) {
+        expect(decoded.getStatus(i)).toBe(originalList[i]);
+      }
+    });
+
+    it('should handle 8-bit status values', () => {
+      const originalList = [0, 1, 127, 128, 255, 42];
+      const statusList = new StatusList(originalList, 8);
+
+      const encoded = encodeStatusListToCBOR(statusList);
+      const decoded = decodeStatusListFromCBOR(encoded);
+
+      for (let i = 0; i < originalList.length; i++) {
+        expect(decoded.getStatus(i)).toBe(originalList[i]);
+      }
+    });
+  });
+
+  describe('encodeCWTPayload / decodeCWTPayload', () => {
+    it('should roundtrip encode and decode CWT payload', () => {
+      const originalList = [1, 0, 1, 1, 0, 1, 0, 1];
+      const statusList = new StatusList(originalList, 1);
+      const subject = 'https://example.com/statuslists/1';
+      const issuedAt = Math.floor(Date.now() / 1000);
+      const exp = issuedAt + 86400;
+      const ttl = 43200;
+
+      const encoded = encodeCWTPayload(statusList, subject, issuedAt, {
+        exp,
+        ttl,
+      });
+      const decoded = decodeCWTPayload(encoded);
+
+      expect(decoded.subject).toBe(subject);
+      expect(decoded.issuedAt).toBe(issuedAt);
+      expect(decoded.exp).toBe(exp);
+      expect(decoded.ttl).toBe(ttl);
+
+      for (let i = 0; i < originalList.length; i++) {
+        expect(decoded.statusList.getStatus(i)).toBe(originalList[i]);
+      }
+    });
+
+    it('should handle payload without optional fields', () => {
+      const originalList = [1, 0, 1, 1, 0];
+      const statusList = new StatusList(originalList, 1);
+      const subject = 'https://example.com/statuslists/1';
+      const issuedAt = Math.floor(Date.now() / 1000);
+
+      const encoded = encodeCWTPayload(statusList, subject, issuedAt);
+      const decoded = decodeCWTPayload(encoded);
+
+      expect(decoded.subject).toBe(subject);
+      expect(decoded.issuedAt).toBe(issuedAt);
+      expect(decoded.exp).toBeUndefined();
+      expect(decoded.ttl).toBeUndefined();
+    });
+  });
+
+  describe('getListFromStatusListCWT', () => {
+    it('should extract status list from CWT payload', () => {
+      const originalList = [1, 0, 1, 1, 0, 1, 0, 1];
+      const statusList = new StatusList(originalList, 1);
+      const subject = 'https://example.com/statuslists/1';
+      const issuedAt = Math.floor(Date.now() / 1000);
+
+      const encoded = encodeCWTPayload(statusList, subject, issuedAt);
+      const extractedList = getListFromStatusListCWT(encoded);
+
+      for (let i = 0; i < originalList.length; i++) {
+        expect(extractedList.getStatus(i)).toBe(originalList[i]);
+      }
+    });
+  });
+
+  describe('CWT Status Claim for Referenced Tokens', () => {
+    it('should create and encode status claim', () => {
+      const idx = 0;
+      const uri = 'https://example.com/statuslists/1';
+
+      const claim = createCWTStatusClaim(idx, uri);
+      expect(claim.status_list.idx).toBe(idx);
+      expect(claim.status_list.uri).toBe(uri);
+
+      const encoded = encodeCWTStatusClaim(idx, uri);
+      const decoded = decodeCWTStatusClaim(encoded);
+
+      expect(decoded.idx).toBe(idx);
+      expect(decoded.uri).toBe(uri);
+    });
+
+    it('should extract status list entry from referenced token CWT', () => {
+      const idx = 42;
+      const uri = 'https://example.com/statuslists/1';
+
+      // Create a CWT payload for a referenced token
+      const payload = new Map<number, unknown>();
+      payload.set(2, 'subject'); // sub
+      payload.set(6, Math.floor(Date.now() / 1000)); // iat
+
+      const statusClaim = new Map<string, unknown>();
+      const statusListInfo = new Map<string, unknown>();
+      statusListInfo.set('idx', idx);
+      statusListInfo.set('uri', uri);
+      statusClaim.set('status_list', statusListInfo);
+      payload.set(65535, statusClaim); // status claim
+
+      const encoded = cbor.encode(payload);
+      const extracted = getStatusListFromCWT(encoded);
+
+      expect(extracted.idx).toBe(idx);
+      expect(extracted.uri).toBe(uri);
+    });
+  });
+
+  describe('Spec compliance - Test vectors', () => {
+    it('should match spec example for 1-bit status list', () => {
+      // From spec: status[0] = 1, status[1] = 0, ...
+      // byte_array = [0xb9, 0xa3]
+      // The spec shows 16 statuses with specific values
+      const statuses = new Array(16).fill(0);
+      statuses[0] = 1;
+      statuses[3] = 1;
+      statuses[4] = 1;
+      statuses[5] = 1;
+      statuses[7] = 1;
+      statuses[8] = 1;
+      statuses[9] = 1;
+      statuses[13] = 1;
+      statuses[15] = 1;
+
+      const list = new StatusList(statuses, 1);
+      const encoded = list.encodeStatusList();
+
+      // The uncompressed byte array should be [0xb9, 0xa3]
+      expect(encoded[0]).toBe(0xb9);
+      expect(encoded[1]).toBe(0xa3);
+    });
+
+    it('should produce CBOR-encoded status list with correct structure', () => {
+      const statuses = [1, 0, 1, 1, 0, 1, 0, 1];
+      const list = new StatusList(statuses, 1);
+
+      const cborEncoded = encodeStatusListToCBOR(list);
+      const decoded = cbor.decode(cborEncoded);
+
+      // Check that the structure has 'bits' and 'lst' keys
+      expect(decoded.bits).toBe(1);
+      expect(decoded.lst).toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  describe('COSEAlgorithms constants', () => {
+    it('should have correct algorithm values', () => {
+      expect(COSEAlgorithms.ES256).toBe(-7);
+      expect(COSEAlgorithms.ES384).toBe(-35);
+      expect(COSEAlgorithms.ES512).toBe(-36);
+      expect(COSEAlgorithms.EdDSA).toBe(-8);
+      expect(COSEAlgorithms.PS256).toBe(-37);
+      expect(COSEAlgorithms.RS256).toBe(-257);
+    });
+  });
+});

--- a/packages/jwt-status-list/src/test/types.spec.ts
+++ b/packages/jwt-status-list/src/test/types.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COSEHeaderKeys,
+  CWT_STATUS_LIST_TYPE,
+  CWTClaimKeys,
+  JWT_STATUS_LIST_TYPE,
+  JWTClaimNames,
+  MediaTypes,
+  StatusTypes,
+} from '../types';
+
+describe('Status List Type Constants', () => {
+  describe('StatusTypes', () => {
+    it('should have correct status type values per spec', () => {
+      // From Section 7 of the spec
+      expect(StatusTypes.VALID).toBe(0x00);
+      expect(StatusTypes.INVALID).toBe(0x01);
+      expect(StatusTypes.SUSPENDED).toBe(0x02);
+      expect(StatusTypes.APPLICATION_SPECIFIC_3).toBe(0x03);
+      expect(StatusTypes.APPLICATION_SPECIFIC_RANGE_START).toBe(0x0c);
+      expect(StatusTypes.APPLICATION_SPECIFIC_RANGE_END).toBe(0x0f);
+    });
+
+    it('should allow using status types with StatusList', () => {
+      // Verify the values can be used as status values
+      expect(StatusTypes.VALID).toBeLessThan(256);
+      expect(StatusTypes.INVALID).toBeLessThan(256);
+      expect(StatusTypes.SUSPENDED).toBeLessThan(256);
+    });
+  });
+
+  describe('MediaTypes', () => {
+    it('should have correct media type values for HTTP content negotiation', () => {
+      // From Section 14.7 of the spec
+      expect(MediaTypes.STATUS_LIST_JWT).toBe('application/statuslist+jwt');
+      expect(MediaTypes.STATUS_LIST_CWT).toBe('application/statuslist+cwt');
+    });
+  });
+
+  describe('JWT Constants', () => {
+    it('should have correct JWT type header value', () => {
+      // From Section 5.1 of the spec
+      expect(JWT_STATUS_LIST_TYPE).toBe('statuslist+jwt');
+    });
+
+    it('should have correct JWT claim names', () => {
+      // From Section 14.1 of the spec
+      expect(JWTClaimNames.STATUS).toBe('status');
+      expect(JWTClaimNames.STATUS_LIST).toBe('status_list');
+      expect(JWTClaimNames.TTL).toBe('ttl');
+      expect(JWTClaimNames.IDX).toBe('idx');
+      expect(JWTClaimNames.URI).toBe('uri');
+      expect(JWTClaimNames.BITS).toBe('bits');
+      expect(JWTClaimNames.LST).toBe('lst');
+      expect(JWTClaimNames.AGGREGATION_URI).toBe('aggregation_uri');
+    });
+  });
+
+  describe('CWT Constants', () => {
+    it('should have correct CWT type value', () => {
+      // From Section 5.2 of the spec
+      expect(CWT_STATUS_LIST_TYPE).toBe('application/statuslist+cwt');
+    });
+
+    it('should have correct CWT claim keys', () => {
+      // From Section 14.3 of the spec
+      expect(CWTClaimKeys.SUB).toBe(2);
+      expect(CWTClaimKeys.EXP).toBe(4);
+      expect(CWTClaimKeys.IAT).toBe(6);
+      expect(CWTClaimKeys.TTL).toBe(65534);
+      expect(CWTClaimKeys.STATUS_LIST).toBe(65533);
+      expect(CWTClaimKeys.STATUS).toBe(65535);
+    });
+
+    it('should have correct COSE header keys', () => {
+      // From IANA COSE registry
+      expect(COSEHeaderKeys.ALG).toBe(1);
+      expect(COSEHeaderKeys.CRIT).toBe(2);
+      expect(COSEHeaderKeys.CONTENT_TYPE).toBe(3);
+      expect(COSEHeaderKeys.KID).toBe(4);
+      expect(COSEHeaderKeys.TYPE).toBe(16);
+      expect(COSEHeaderKeys.X5CHAIN).toBe(33);
+      expect(COSEHeaderKeys.X5T).toBe(34);
+      expect(COSEHeaderKeys.X5U).toBe(35);
+    });
+  });
+});

--- a/packages/jwt-status-list/src/types.ts
+++ b/packages/jwt-status-list/src/types.ts
@@ -1,5 +1,74 @@
 import type { JwtPayload } from '@sd-jwt/types';
 
+// ==================== Common Types & Constants ====================
+
+/**
+ * Status Type values as defined in the spec.
+ * These represent the possible status values for a Referenced Token.
+ * @see https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html#section-7
+ */
+export const StatusTypes = {
+  /** The status of the Referenced Token is valid, correct or legal. */
+  VALID: 0x00,
+  /** The status of the Referenced Token is revoked, annulled, taken back, recalled or cancelled. */
+  INVALID: 0x01,
+  /** The status of the Referenced Token is temporarily invalid, hanging, debarred from privilege. This status is usually temporary. */
+  SUSPENDED: 0x02,
+  /** Application-specific status (0x03). The processing is application specific. */
+  APPLICATION_SPECIFIC_3: 0x03,
+  /** Application-specific status range start (0x0C). Values 0x0C-0x0F are reserved for application specific use. */
+  APPLICATION_SPECIFIC_RANGE_START: 0x0c,
+  /** Application-specific status range end (0x0F). Values 0x0C-0x0F are reserved for application specific use. */
+  APPLICATION_SPECIFIC_RANGE_END: 0x0f,
+} as const;
+
+export type StatusType =
+  | (typeof StatusTypes)[keyof typeof StatusTypes]
+  | number;
+
+/**
+ * Media types for Status List Tokens
+ * Used for HTTP Content-Type and Accept headers
+ * @see https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html#section-14.7
+ */
+export const MediaTypes = {
+  /** Media type for JWT-based Status List Token */
+  STATUS_LIST_JWT: 'application/statuslist+jwt',
+  /** Media type for CWT-based Status List Token */
+  STATUS_LIST_CWT: 'application/statuslist+cwt',
+} as const;
+
+// ==================== JWT Types & Constants ====================
+
+/**
+ * JWT type header value for Status List Token
+ * @see https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html#section-5.1
+ */
+export const JWT_STATUS_LIST_TYPE = 'statuslist+jwt';
+
+/**
+ * JWT claim names for Status List
+ * @see https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html#section-14.1
+ */
+export const JWTClaimNames = {
+  /** Status claim - contains a reference to a status mechanism */
+  STATUS: 'status',
+  /** Status list claim - contains the status list data */
+  STATUS_LIST: 'status_list',
+  /** Time to live claim */
+  TTL: 'ttl',
+  /** Index field in status_list reference */
+  IDX: 'idx',
+  /** URI field in status_list reference */
+  URI: 'uri',
+  /** Bits field in status_list */
+  BITS: 'bits',
+  /** List field in status_list (base64url encoded) */
+  LST: 'lst',
+  /** Aggregation URI field */
+  AGGREGATION_URI: 'aggregation_uri',
+} as const;
+
 /**
  * Reference to a status list entry.
  */
@@ -34,10 +103,160 @@ export interface StatusListJWTPayload extends JwtPayload {
 export type BitsPerStatus = 1 | 2 | 4 | 8;
 
 /**
- * Header parameters for a JWT.
+ * Header parameters for a JWT Status List Token.
  */
 export type StatusListJWTHeaderParameters = {
   alg: string;
-  typ: 'statuslist+jwt';
+  typ: typeof JWT_STATUS_LIST_TYPE;
   [key: string]: unknown;
 };
+
+// ==================== CWT Types ====================
+
+/**
+ * CWT Claim Keys as defined in draft-ietf-oauth-status-list
+ * @see https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html#section-5.2
+ */
+export const CWTClaimKeys = {
+  /** Subject claim (sub) */
+  SUB: 2,
+  /** Expiration time claim (exp) */
+  EXP: 4,
+  /** Issued at claim (iat) */
+  IAT: 6,
+  /** Time to live claim (ttl) */
+  TTL: 65534,
+  /** Status list claim */
+  STATUS_LIST: 65533,
+  /** Status claim for referenced tokens */
+  STATUS: 65535,
+} as const;
+
+/**
+ * CWT Status List map keys
+ */
+export const CWTStatusListKeys = {
+  /** bits field in status_list */
+  BITS: 'bits',
+  /** lst field in status_list (compressed byte array) */
+  LST: 'lst',
+  /** aggregation_uri field in status_list */
+  AGGREGATION_URI: 'aggregation_uri',
+} as const;
+
+/**
+ * CWT Status List Info keys (for referenced tokens)
+ */
+export const CWTStatusListInfoKeys = {
+  /** idx field */
+  IDX: 'idx',
+  /** uri field */
+  URI: 'uri',
+} as const;
+
+/**
+ * COSE Header type parameter value for Status List CWT (string form)
+ * The type can be either this media type string OR the registered CoAP Content-Format ID.
+ * @see https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html#section-5.2
+ * @see https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html#section-14.8
+ */
+export const CWT_STATUS_LIST_TYPE = 'application/statuslist+cwt';
+
+/**
+ * CoAP Content-Format ID for Status List CWT (numeric form)
+ * This is a placeholder - the actual value is TBD in the IANA registry.
+ * Once assigned, this can be used as an alternative to CWT_STATUS_LIST_TYPE string.
+ * @see https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html#section-14.8
+ */
+export const CWT_STATUS_LIST_CONTENT_FORMAT_ID: number | undefined = undefined;
+
+/**
+ * COSE Header parameter keys
+ * @see https://www.iana.org/assignments/cose/cose.xhtml#header-parameters
+ * @see https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html#section-11.3
+ */
+export const COSEHeaderKeys = {
+  /** Algorithm */
+  ALG: 1,
+  /** Critical */
+  CRIT: 2,
+  /** Content Type */
+  CONTENT_TYPE: 3,
+  /** Key ID */
+  KID: 4,
+  /** IV (Initialization Vector) */
+  IV: 5,
+  /** Partial IV */
+  PARTIAL_IV: 6,
+  /** Type (from RFC 9596) */
+  TYPE: 16,
+  /** X.509 certificate chain (for key resolution) */
+  X5CHAIN: 33,
+  /** X.509 certificate SHA-256 thumbprint (for key resolution) */
+  X5T: 34,
+  /** X.509 URL (for key resolution) */
+  X5U: 35,
+} as const;
+
+/**
+ * Status List in CBOR format
+ * The lst field is a raw byte string (not base64url encoded like in JWT)
+ */
+export interface StatusListCBOR {
+  bits: BitsPerStatus;
+  lst: Uint8Array;
+  aggregation_uri?: string;
+}
+
+/**
+ * CWT Claims Set for a Status List Token
+ * Uses numeric keys as defined in the spec
+ */
+export interface StatusListCWTPayload {
+  /** Subject (claim key 2) - URI of the Status List Token */
+  [CWTClaimKeys.SUB]: string;
+  /** Issued at (claim key 6) - Unix timestamp */
+  [CWTClaimKeys.IAT]: number;
+  /** Expiration time (claim key 4) - Unix timestamp (optional but recommended) */
+  [CWTClaimKeys.EXP]?: number;
+  /** Time to live (claim key 65534) - seconds (optional but recommended) */
+  [CWTClaimKeys.TTL]?: number;
+  /** Status list (claim key 65533) */
+  [CWTClaimKeys.STATUS_LIST]: StatusListCBOR;
+}
+
+/**
+ * CWT Claims Set for a Referenced Token with status
+ */
+export interface CWTwithStatusListPayload {
+  /** Subject (claim key 2) */
+  [CWTClaimKeys.SUB]?: string;
+  /** Issued at (claim key 6) */
+  [CWTClaimKeys.IAT]?: number;
+  /** Expiration time (claim key 4) */
+  [CWTClaimKeys.EXP]?: number;
+  /** Status (claim key 65535) */
+  [CWTClaimKeys.STATUS]: {
+    status_list: StatusListEntry;
+  };
+}
+
+/**
+ * COSE protected header for Status List CWT
+ * @see https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html#section-5.2
+ * @see https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-16.html#section-11.3
+ */
+export interface StatusListCWTHeader {
+  /** Algorithm (key 1) - REQUIRED */
+  [COSEHeaderKeys.ALG]: number;
+  /** Type (key 16) - REQUIRED. Should be 'application/statuslist+cwt' or CoAP Content-Format ID */
+  [COSEHeaderKeys.TYPE]: string | number;
+  /** Key ID (key 4) - optional, for key resolution */
+  [COSEHeaderKeys.KID]?: Uint8Array | string;
+  /** X.509 certificate chain (key 33) - optional, for key resolution */
+  [COSEHeaderKeys.X5CHAIN]?: Uint8Array | Uint8Array[];
+  /** X.509 certificate SHA-256 thumbprint (key 34) - optional, for key resolution */
+  [COSEHeaderKeys.X5T]?: Uint8Array;
+  /** X.509 URL (key 35) - optional, for key resolution */
+  [COSEHeaderKeys.X5U]?: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@sd-jwt/utils':
         specifier: workspace:*
         version: link:../utils
+      cbor-x:
+        specifier: ^1.6.0
+        version: 1.6.0
       pako:
         specifier: ^2.1.0
         version: 2.1.0
@@ -312,6 +315,36 @@ packages:
   '@biomejs/cli-win32-x64@2.3.8':
     resolution: {integrity: sha512-RguzimPoZWtBapfKhKjcWXBVI91tiSprqdBYu7tWhgN8pKRZhw24rFeNZTNf6UiBfjCYCi9eFQs/JzJZIhuK4w==}
     engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.0':
+    resolution: {integrity: sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.0':
+    resolution: {integrity: sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.0':
+    resolution: {integrity: sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.0':
+    resolution: {integrity: sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==}
+    cpu: [arm]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.0':
+    resolution: {integrity: sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.0':
+    resolution: {integrity: sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==}
     cpu: [x64]
     os: [win32]
 
@@ -1492,6 +1525,13 @@ packages:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
+  cbor-extract@2.2.0:
+    resolution: {integrity: sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==}
+    hasBin: true
+
+  cbor-x@1.6.0:
+    resolution: {integrity: sha512-0kareyRwHSkL6ws5VXHEf8uY1liitysCVJjlmhaLG+IXLqhSaOO+t63coaso7yjwEzWZzLy8fJo06gZDVQM9Qg==}
+
   chai@6.2.1:
     resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
     engines: {node: '>=18'}
@@ -1731,6 +1771,10 @@ packages:
   detect-indent@5.0.0:
     resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
     engines: {node: '>=4'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -2582,6 +2626,10 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-gyp-build-optional-packages@5.1.1:
+    resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
+    hasBin: true
 
   node-gyp@11.5.0:
     resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
@@ -3735,6 +3783,24 @@ snapshots:
   '@biomejs/cli-win32-x64@2.3.8':
     optional: true
 
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.0':
+    optional: true
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.0':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.0':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.0':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.0':
+    optional: true
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.0':
+    optional: true
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -4859,6 +4925,22 @@ snapshots:
 
   camelcase@5.3.1: {}
 
+  cbor-extract@2.2.0:
+    dependencies:
+      node-gyp-build-optional-packages: 5.1.1
+    optionalDependencies:
+      '@cbor-extract/cbor-extract-darwin-arm64': 2.2.0
+      '@cbor-extract/cbor-extract-darwin-x64': 2.2.0
+      '@cbor-extract/cbor-extract-linux-arm': 2.2.0
+      '@cbor-extract/cbor-extract-linux-arm64': 2.2.0
+      '@cbor-extract/cbor-extract-linux-x64': 2.2.0
+      '@cbor-extract/cbor-extract-win32-x64': 2.2.0
+    optional: true
+
+  cbor-x@1.6.0:
+    optionalDependencies:
+      cbor-extract: 2.2.0
+
   chai@6.2.1: {}
 
   chalk@4.1.0:
@@ -5075,6 +5157,9 @@ snapshots:
   deprecation@2.3.1: {}
 
   detect-indent@5.0.0: {}
+
+  detect-libc@2.1.2:
+    optional: true
 
   diff@4.0.2: {}
 
@@ -6079,6 +6164,11 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
+
+  node-gyp-build-optional-packages@5.1.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-gyp@11.5.0:
     dependencies:


### PR DESCRIPTION
Allows to issue the status list also as CWT compared to JWT.

Also adds some reusable variables that are defined in the spec.

A renaming of the package is not done. When this gets moved to the new Lab as a core library, new package names can be defined (core for bit string logic, one for JWT and one for CWT to minimize dependencies in them)

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>