### PR TITLE
fix(sd-jwt-vc): config param type override in SDJwtVcInstance

### DIFF
--- a/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
+++ b/packages/sd-jwt-vc/src/sd-jwt-vc-instance.ts
@@ -670,4 +670,8 @@ export class SDJwtVcInstance extends SDJwtInstance<SdJwtVcPayload> {
       }
     }
   }
+
+  public config(newConfig: SDJWTVCConfig) {
+    super.config(newConfig);
+  }
 }


### PR DESCRIPTION
Allows replacing the full configuration. At the moment that wasn't possible without a forced cast because it was using the type of the class it extends.